### PR TITLE
Adds tests tab to sprints, adds support for linking runs to sprints and rendering linked runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,12 @@
           "recordTypes": [
             "Feature",
             "Requirement",
-            "Epic"
+            "Epic",
+            "Iteration"
           ]
         },
         "syncing": {
-          "title": "TestRail Syncing",
+          "title": "TestRail Connection",
           "entryPoint": "src/views/syncing.tsx",
           "host": "page",
           "location": {

--- a/src/components/Styles.tsx
+++ b/src/components/Styles.tsx
@@ -33,6 +33,10 @@ export const Styles = () => {
           font-weight: 600;
         }
 
+        .has-pointer {
+          cursor: pointer;
+        }
+
         .tab-header {
           display: flex;
           justify-content: space-between;
@@ -271,6 +275,50 @@ export const Styles = () => {
 
         .left-align-input {
           --aha-field--label-width: inherit;
+        }
+
+        .run-rows {
+          display: flex;
+          flex-direction: column;
+          gap: var(--spacer-3);
+        }
+
+        .run-row {
+          border: var(--Common--border);
+          padding: var(--spacer-4) var(--spacer-3);
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+        }
+
+        .run-row-column {
+          display: flex;
+          align-items: center;
+          gap: var(--spacer-2);
+        }
+
+        .run-rows .test-row {
+          background-color: var(--theme-secondary-background);
+        }
+
+        .run-title {
+          font-weight: 500;
+          font-size: var(--font-size-100);
+        }
+
+        .run-stat-row {
+          display: flex;
+          gap: var(--spacer-2);
+        }
+
+        .status-count {
+          display: flex;
+          gap: var(--spacer);
+        }
+
+        .test-status {
+          min-width: 62px;
+          text-align: center;
         }
       `}
     </style>

--- a/src/components/modals/CreateTestCase.tsx
+++ b/src/components/modals/CreateTestCase.tsx
@@ -4,7 +4,7 @@ import { ExtensionRecord } from '../../lib/extensionRecord';
 import SearchByName, { TreeNode } from './SearchByName';
 import {
   getRecords,
-  getProjectSections,
+  getProjectRecords,
 } from '../../lib/extensionFields/queries';
 import { waitForLambda } from '../../lib/sync/interface';
 import { APIResult } from '../../lib/api';
@@ -210,7 +210,7 @@ const CreateTestCase: React.FC<Props> = ({
       );
 
       const [sectionMapping, projects] = await Promise.all([
-        getProjectSections(projectIds),
+        getProjectRecords<Section>(projectIds, 'Section'),
         getRecords<Project>(projectIds, 'Project'),
       ]);
 
@@ -230,7 +230,7 @@ const CreateTestCase: React.FC<Props> = ({
       setSyncingSections(currentState);
     }
 
-    if (loading || (!lastState && currentState)) fetchSections();
+    if (loading || (lastState && !currentState)) fetchSections();
   }, [syncData]);
 
   useEffect(() => {

--- a/src/components/modals/LinkTest.tsx
+++ b/src/components/modals/LinkTest.tsx
@@ -7,11 +7,12 @@ import { linkRecord } from '../../lib/extensionFields/updates';
 
 type Props = {
   record: ExtensionRecord;
+  caseIds: number[];
   syncData: BulkSyncState;
   onClose: () => void;
 };
 
-const LinkTest: React.FC<Props> = ({ record, syncData, onClose }) => {
+const LinkTest: React.FC<Props> = ({ record, caseIds, syncData, onClose }) => {
   const modalRef = useRef(null);
   const [saving, setSaving] = useState(false);
 
@@ -61,9 +62,9 @@ const LinkTest: React.FC<Props> = ({ record, syncData, onClose }) => {
         )}
         <div style={{ display: caseStep ? 'block' : 'none' }}>
           <SelectTestCase
-            record={record}
             syncData={syncData}
             caseId={caseId}
+            caseIds={caseIds}
             setCaseId={async (value: string) => setCaseId(value)}
           />
         </div>

--- a/src/components/modals/LinkTestCase.tsx
+++ b/src/components/modals/LinkTestCase.tsx
@@ -6,11 +6,17 @@ import { linkRecord } from '../../lib/extensionFields/updates';
 
 type Props = {
   record: ExtensionRecord;
+  caseIds: number[];
   syncData: BulkSyncState;
   onClose: () => void;
 };
 
-const LinkTestCase: React.FC<Props> = ({ record, syncData, onClose }) => {
+const LinkTestCase: React.FC<Props> = ({
+  record,
+  caseIds,
+  syncData,
+  onClose,
+}) => {
   const modalRef = useRef(null);
 
   const [caseId, setCaseId] = useState<string>(null);
@@ -58,7 +64,7 @@ const LinkTestCase: React.FC<Props> = ({ record, syncData, onClose }) => {
           </aha-alert>
         )}
         <SelectTestCase
-          record={record}
+          caseIds={caseIds}
           syncData={syncData}
           caseId={caseId}
           setCaseId={updateCaseId}

--- a/src/components/modals/LinkTestRun.tsx
+++ b/src/components/modals/LinkTestRun.tsx
@@ -1,0 +1,238 @@
+import React, { useEffect, useState, useRef } from 'react';
+import { IDENTIFIER, Project, TestRun } from '../../extension';
+import { ExtensionRecord } from '../../lib/extensionRecord';
+import SearchByName, { TreeNode } from './SearchByName';
+import {
+  getRecords,
+  getProjectRecords,
+} from '../../lib/extensionFields/queries';
+import { linkRecord } from '../../lib/extensionFields/updates';
+import { BulkSyncState, SyncStage, SyncState } from '../../lib/sync/bulkSync';
+import SyncProgress from '../SyncProgress';
+
+type Props = {
+  record: ExtensionRecord;
+  runIds: number[] | undefined;
+  syncData: BulkSyncState;
+  onClose: () => void;
+};
+
+const runOptions: (
+  projects: Project[],
+  runMapping: {
+    [projectId: string]: TestRun[];
+  },
+  runIds: number[]
+) => TreeNode[] = (projects, runMapping, runIds) => {
+  const options: TreeNode[] = [];
+
+  let idMapping: { [runId: number]: boolean } = [];
+
+  if (runIds && runIds.length) {
+    idMapping = runIds.reduce((acc, id) => {
+      acc[id] = true;
+      return acc;
+    }, {});
+  }
+
+  for (const project of projects) {
+    const runs = runMapping[project.id] || [];
+
+    const openRuns = [];
+    const completedRuns = [];
+
+    for (const run of runs) {
+      if (idMapping[run.id]) continue;
+
+      if (run.completed) {
+        completedRuns.push(run);
+      } else {
+        openRuns.push(run);
+      }
+    }
+
+    let openHeader: TreeNode = null;
+    let completedHeader: TreeNode = null;
+
+    if (openRuns.length) {
+      openHeader = {
+        value: project.id.toString(),
+        text: 'Open runs',
+        header: true,
+        children: openRuns.map(r => ({
+          text: r.name,
+          value: `${r.id}`,
+          date: r.createdOn * 1000,
+        })),
+      };
+    }
+
+    if (completedRuns.length) {
+      completedHeader = {
+        value: project.id.toString(),
+        text: 'Completed runs',
+        header: true,
+        children: completedRuns.map(r => ({
+          text: r.name,
+          value: `${r.id}`,
+          date: r.createdOn * 1000,
+        })),
+      };
+    }
+
+    const children = [openHeader, completedHeader].filter(Boolean);
+
+    if (children.length === 0) continue;
+
+    const header: TreeNode = {
+      value: project.id.toString(),
+      text: project.name,
+      children,
+    };
+
+    options.push(header);
+  }
+
+  return options;
+};
+
+const findChild: (node: TreeNode, value: string) => boolean = (node, value) => {
+  if (node.value === value) {
+    return true;
+  }
+
+  if (!node.children) return false;
+
+  for (const child of node.children) {
+    if (findChild(child, value)) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const LinkTestRun: React.FC<Props> = ({
+  record,
+  runIds,
+  syncData,
+  onClose,
+}) => {
+  const modalRef = useRef(null);
+  const runIdRef = useRef(null);
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const [syncing, setSyncing] = useState(null);
+  const [syncStage, setSyncStage] = useState(syncData?.stage);
+
+  const [runId, setRunId] = useState<string>(null);
+  const [runTree, setRunTree] = useState<TreeNode[]>([]);
+
+  const updateRunId = async value => {
+    runIdRef.current = value; // Use this as a cache, the state is not updated immediately
+    setRunId(value);
+  };
+
+  const submit = async () => {
+    if (!runIdRef.current) return;
+
+    setSaving(true);
+
+    await linkRecord(record, Number.parseInt(runIdRef.current), 'runIds');
+
+    setSaving(false);
+    onClose();
+  };
+
+  useEffect(() => {
+    const fetchRuns = async () => {
+      const projectIds = await aha.account.getExtensionField<number[]>(
+        IDENTIFIER,
+        'projectIds'
+      );
+
+      const [runMapping, projects] = await Promise.all([
+        getProjectRecords<TestRun>(projectIds, 'TestRun'),
+        getRecords<Project>(projectIds, 'Project'),
+      ]);
+
+      setRunTree(runOptions(projects, runMapping, runIds));
+      setLoading(false);
+    };
+
+    if (syncData && syncing === null) {
+      setSyncing(syncData.state !== SyncState.Complete);
+    }
+
+    const lastStage = syncStage;
+    let currentStage = syncStage;
+
+    if (syncData) {
+      currentStage = syncData.stage;
+      setSyncStage(currentStage);
+    }
+
+    const syncedRuns =
+      lastStage &&
+      lastStage >= SyncStage.OpenRuns &&
+      lastStage <= SyncStage.CompletedPlans &&
+      lastStage !== currentStage;
+
+    if (loading || syncedRuns) fetchRuns();
+  }, [syncData]);
+
+  useEffect(() => {
+    const modal = modalRef.current;
+    modal.addEventListener('aha-modal:close', onClose);
+
+    return () => {
+      modal.removeEventListener('aha-modal:close', onClose);
+    };
+  }, [onClose]);
+
+  return (
+    <aha-modal ref={modalRef} open position='h-center' size='medium'>
+      <aha-modal-header modalTitle='Link test run'>
+        Link test run
+      </aha-modal-header>
+      <aha-modal-body>
+        {syncData && !syncData.lastSync && (
+          <aha-alert class='mb-5' type='warning' dismissable>
+            <div slot='heading'>We haven't fully synced with TestRail yet.</div>
+            We're still gathering data from the TestRail API, so search results
+            will be incomplete. Please remain on the tests tab until it has
+            finished.
+          </aha-alert>
+        )}
+        <div className='search-form'>
+          <SearchByName
+            tree={runTree}
+            selected={[runId]}
+            onSelect={updateRunId}
+            recordName='test run'
+            showReference={true}
+            referencePrefix='R'
+            loading={loading}
+            label='Select a test run'
+            placeholder={'No synced test runs found.'}
+          >
+            {syncing && <SyncProgress syncData={syncData} />}
+          </SearchByName>
+        </div>
+      </aha-modal-body>
+      <aha-modal-footer>
+        <aha-button
+          kind='primary'
+          disabled={loading || saving || !runId ? true : null}
+          onClick={submit}
+        >
+          {saving ? 'Linking...' : 'Link test run'}
+        </aha-button>
+      </aha-modal-footer>
+    </aha-modal>
+  );
+};
+
+export default LinkTestRun;

--- a/src/components/modals/SearchByName.tsx
+++ b/src/components/modals/SearchByName.tsx
@@ -7,6 +7,7 @@ export type TreeNode = {
   text: string;
   date?: number;
   children?: TreeNode[];
+  header?: boolean;
 };
 
 type CommonProps = {
@@ -52,7 +53,8 @@ const ResultSection: React.FC<SectionProps> = ({
 
     return (
       node.children?.some(child => matchesQuery(child)) ||
-      queryText.toLowerCase().includes(query.trim().toLowerCase())
+      (!node.header &&
+        queryText.toLowerCase().includes(query.trim().toLowerCase()))
     );
   };
 
@@ -66,46 +68,51 @@ const ResultSection: React.FC<SectionProps> = ({
 
   return (
     <>
-      {nesting === 0 && (
+      {(nesting === 0 || tree.header) && (
         <div key={key} className='search-row' style={style}>
           <div className='search-header'>{tree.text}</div>
         </div>
       )}
       {filtered.map(node => (
         <>
-          <div
-            key={node.value}
-            className={`search-row${
-              selected.includes(node.value) ? ' selected' : ''
-            }`}
-            style={style}
-            onClick={onSelectBuilder(node.value)}
-          >
-            <div className='search-result'>
-              <div className='search-column'>
-                {selected.includes(node.value) ? (
-                  <aha-icon class='search-selected' icon='fa-solid fa-check' />
-                ) : (
-                  <aha-icon icon='fa-regular fa-square' />
-                )}
-
-                <div className='search-text'>
-                  {showReference && (
-                    <div className='text-light text-gray'>{`${referencePrefix}${node.value}`}</div>
+          {!node.header && (
+            <div
+              key={node.value}
+              className={`search-row${
+                selected.includes(node.value) ? ' selected' : ''
+              }`}
+              style={style}
+              onClick={onSelectBuilder(node.value)}
+            >
+              <div className='search-result'>
+                <div className='search-column'>
+                  {selected.includes(node.value) ? (
+                    <aha-icon
+                      class='search-selected'
+                      icon='fa-solid fa-check'
+                    />
+                  ) : (
+                    <aha-icon icon='fa-regular fa-square' />
                   )}
 
-                  <div className={node.children ? 'search-sub-header' : null}>
-                    {node.text}
+                  <div className='search-text'>
+                    {showReference && (
+                      <div className='text-light text-gray'>{`${referencePrefix}${node.value}`}</div>
+                    )}
+
+                    <div className={node.children ? 'search-sub-header' : null}>
+                      {node.text}
+                    </div>
                   </div>
                 </div>
+                {node.date && (
+                  <div className='text-light text-gray'>
+                    {formatTime(node.date)}
+                  </div>
+                )}
               </div>
-              {node.date && (
-                <div className='text-light text-gray'>
-                  {formatTime(node.date)}
-                </div>
-              )}
             </div>
-          </div>
+          )}
           {node.children && (
             <ResultSection
               tree={node}

--- a/src/components/modals/SelectTest.tsx
+++ b/src/components/modals/SelectTest.tsx
@@ -83,7 +83,7 @@ const SelectTest: React.FC<Props> = ({
 
     // Load on first render, if caseId changes, or if new tests potentially synced
     const shouldLoad =
-      caseId && (loading || caseIdChanged || (!lastState && currentState));
+      caseId && (loading || caseIdChanged || (lastState && !currentState));
 
     if (caseId && caseIdChanged) {
       setLoading(true);

--- a/src/components/modals/SelectTestCase.tsx
+++ b/src/components/modals/SelectTestCase.tsx
@@ -4,15 +4,15 @@ import SyncProgress from '../SyncProgress';
 import { IDENTIFIER, Project, TestCase } from '../../extension';
 import {
   getRecords,
-  getProjectTestCases,
+  getProjectRecords,
 } from '../../lib/extensionFields/queries';
 import { ExtensionRecord } from '../../lib/extensionRecord';
 import { BulkSyncState, SyncStage, SyncState } from '../../lib/sync/bulkSync';
 
 type Props = {
-  record: ExtensionRecord;
   syncData: BulkSyncState;
   caseId: string;
+  caseIds: number[];
   setCaseId: (caseId: string) => Promise<void>;
 };
 
@@ -57,9 +57,9 @@ const caseOptions: (
 };
 
 const SelectTestCase: React.FC<Props> = ({
-  record,
   syncData,
   caseId,
+  caseIds,
   setCaseId,
 }) => {
   const [loading, setLoading] = useState(true);
@@ -75,13 +75,8 @@ const SelectTestCase: React.FC<Props> = ({
         'projectIds'
       );
 
-      const caseIds = await record.getExtensionField<number[]>(
-        IDENTIFIER,
-        'caseIds'
-      );
-
       const [caseMapping, projects] = await Promise.all([
-        getProjectTestCases(projectIds),
+        getProjectRecords<TestCase>(projectIds, 'TestCase'),
         getRecords<Project>(projectIds, 'Project'),
       ]);
 
@@ -102,7 +97,7 @@ const SelectTestCase: React.FC<Props> = ({
     }
 
     // Fetch data on first load or if new cases potentially synced
-    if (loading || (!lastState && currentState)) fetchCases();
+    if (loading || (lastState && !currentState)) fetchCases();
   }, [syncData]);
 
   return (

--- a/src/components/tabs/FeatureTab.tsx
+++ b/src/components/tabs/FeatureTab.tsx
@@ -83,18 +83,20 @@ const FeatureTab: React.FC<TabProps> = ({ record, fields, settings }) => {
       const tabData = await getFeatureTabData(caseIds, testIds);
 
       setTabData(tabData);
-      waitForBulkSync({
-        domain,
-        syncDelay,
-        setState: setSyncData,
-        reload: reloadTabData,
-      });
-
       setLoading(false);
     }
 
     initData();
   }, [caseIds, testIds, reload]);
+
+  useEffect(() => {
+    waitForBulkSync({
+      domain,
+      syncDelay,
+      setState: setSyncData,
+      reload: reloadTabData,
+    });
+  }, []);
 
   let caseRows = null;
 
@@ -102,7 +104,7 @@ const FeatureTab: React.FC<TabProps> = ({ record, fields, settings }) => {
     testCases: [],
     tests: {},
     comments: {},
-    statuses: [],
+    statuses: {},
   };
 
   if (caseIds) {
@@ -171,6 +173,7 @@ const FeatureTab: React.FC<TabProps> = ({ record, fields, settings }) => {
         {linkCaseModalOpen && (
           <LinkTestCase
             record={record}
+            caseIds={caseIds}
             syncData={syncData}
             onClose={onClose(setLinkCaseModalOpen)}
           />
@@ -178,6 +181,7 @@ const FeatureTab: React.FC<TabProps> = ({ record, fields, settings }) => {
         {linkTestModalOpen && (
           <LinkTest
             record={record}
+            caseIds={caseIds}
             syncData={syncData}
             onClose={onClose(setLinkTestModalOpen)}
           />

--- a/src/components/tabs/RunRow.tsx
+++ b/src/components/tabs/RunRow.tsx
@@ -1,0 +1,132 @@
+import React, { useState } from 'react';
+import { TestCase, TestRun, Test, Status } from '../../extension';
+import { ExtensionRecord } from '../../lib/extensionRecord';
+import { unlinkRecord } from '../../lib/extensionFields/updates';
+import RecordLink from '../RecordLink';
+import TestRow from './TestRow';
+import { numberToColor } from '../../lib/util';
+
+const PASSED_STATUS_ID = 1; // True for all TestRail accounts
+
+type Props = {
+  run: TestRun;
+  rows: [TestCase, Test][];
+  comments: { [testId: number]: { timestamp: number; comment: string } };
+  statuses: { [statusId: number]: Status };
+  domain: string;
+  record: ExtensionRecord;
+};
+
+type ExpanderProps = {
+  expanded: boolean;
+  onClick: (value: boolean) => void;
+};
+
+const getPassedPercentage: (
+  rows: [TestCase, Test][],
+  passed: number
+) => number = (rows, passed) => {
+  const total = rows.length;
+  return Math.round((passed / total) * 100);
+};
+
+const Expander: React.FC<ExpanderProps> = ({ expanded, onClick }) => {
+  const icon = expanded ? 'fa-chevron-up' : 'fa-chevron-down';
+
+  return (
+    <div className='has-pointer text-gray' onClick={() => onClick(!expanded)}>
+      <aha-icon icon={`fa-regular ${icon}`} />
+    </div>
+  );
+};
+
+const StatusCount: React.FC<{ status?: Status; count: number }> = ({
+  status,
+  count,
+}) => {
+  if (!status) return null;
+
+  return (
+    <div className='status-count text-small'>
+      <aha-icon
+        style={{ color: numberToColor(status.colorMedium) }}
+        icon='fa-solid fa-square'
+      />
+      <span>{count}</span>
+      <span>{status.label}</span>
+    </div>
+  );
+};
+
+const RunRow: React.FC<Props> = ({
+  run,
+  rows,
+  comments,
+  statuses,
+  domain,
+  record,
+}) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const statusCounts = rows.reduce((acc, [, test]) => {
+    acc[test.statusId] = (acc[test.statusId] || 0) + 1;
+    return acc;
+  }, {});
+
+  return (
+    <div>
+      <div className='run-row'>
+        <div className='run-row-column'>
+          <Expander expanded={expanded} onClick={setExpanded} />
+          <div className='run-stats'>
+            <div className='run-title'>
+              <span className='mr-2 text-light'>
+                <RecordLink record={run} domain={domain} />
+              </span>
+              {run.name}
+            </div>
+            <div className='run-stat-row'>
+              {Object.keys(statusCounts).map(statusId => (
+                <StatusCount
+                  status={statuses[statusId]}
+                  count={statusCounts[statusId]}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+        <div className='run-row-column'>
+          <div className='text-gray text-small'>
+            {getPassedPercentage(rows, statusCounts[PASSED_STATUS_ID] || 0)}%
+            complete
+          </div>
+          <aha-pill color='var(--theme-tertiary-background)'>
+            {run.completed ? 'Run complete' : 'Run open'}
+          </aha-pill>
+          <aha-button
+            size='mini'
+            kind='icon'
+            onClick={() => unlinkRecord(record, run.id, 'runIds')}
+          >
+            <aha-icon icon='fa-regular fa-trash-can' />
+          </aha-button>
+        </div>
+      </div>
+      {expanded &&
+        rows.map(([testCase, test]) => (
+          <TestRow
+            key={test.id}
+            testCase={testCase}
+            test={test}
+            comment={comments[test.id]}
+            status={statuses[test.statusId]}
+            domain={domain}
+            record={record}
+            canDelete={false}
+          />
+        ))}
+    </div>
+  );
+};
+
+export default RunRow;

--- a/src/components/tabs/SprintTab.tsx
+++ b/src/components/tabs/SprintTab.tsx
@@ -1,0 +1,186 @@
+import React, { useEffect, useState } from 'react';
+import { TestCase, TestRun, Test, Status } from '../../extension';
+import {
+  getRecords,
+  getLinkedComments,
+  getRunRowData,
+} from '../../lib/extensionFields/queries';
+import { timeAgo } from '../../lib/util';
+import { Styles } from '../Styles';
+import { ExtensionRecord } from '../../lib/extensionRecord';
+import { BulkSyncState, SyncState } from '../../lib/sync/bulkSync';
+import waitForBulkSync from '../../lib/sync/waitForBulkSync';
+import LinkTestRun from '../modals/LinkTestRun';
+import RunRow from './RunRow';
+
+type TabProps = {
+  record: ExtensionRecord;
+  fields: Record<string, unknown>;
+  settings: Aha.Settings;
+};
+
+type TestMap = { [runId: number]: [TestCase, Test][] };
+
+type SprintTabData = {
+  runs: TestRun[];
+  testMap: TestMap;
+  comments: { [testId: number]: { timestamp: number; comment: string } };
+  statuses: { [key: string]: Status };
+};
+
+export async function getSprintTabData(
+  runIds: number[]
+): Promise<SprintTabData> {
+  const runs = await getRecords<TestRun>(runIds, 'TestRun');
+  const [testMap, tests] = await getRunRowData(runIds);
+
+  const commentMap = await getLinkedComments(tests);
+
+  const statusIds = tests.map(test => test.statusId);
+  const statuses = await getRecords<Status>(statusIds, 'Status');
+  const statusMap = statuses.reduce((acc, status) => {
+    acc[status.id] = status;
+    return acc;
+  }, {});
+
+  return {
+    runs,
+    testMap,
+    comments: commentMap,
+    statuses: statusMap,
+  };
+}
+
+const SprintTab: React.FC<TabProps> = ({ record, fields, settings }) => {
+  const runIds = fields['runIds'] as number[] | undefined;
+
+  const [loading, setLoading] = useState(true);
+  const [syncData, setSyncData] = useState<BulkSyncState>(null);
+  const [tabData, setTabData] = useState<SprintTabData>(null);
+
+  const [linkRunModalOpen, setLinkRunModalOpen] = useState(false);
+
+  // Used to re-trigger the useEffect and reload the data.
+  const [reload, setReload] = useState(0);
+  const reloadTabData = () => setReload(reload + 1);
+
+  const domain = settings.get('domain') as string | undefined;
+  const syncDelay = settings.get('syncDelay') as number | undefined;
+
+  useEffect(() => {
+    async function initData() {
+      const tabData = await getSprintTabData(runIds);
+
+      setTabData(tabData);
+      setLoading(false);
+    }
+
+    initData();
+  }, [runIds, reload]);
+
+  useEffect(() => {
+    waitForBulkSync({
+      domain,
+      syncDelay,
+      setState: setSyncData,
+      reload: reloadTabData,
+    });
+  }, []);
+
+  let runRows = null;
+
+  const { runs, testMap, comments, statuses } = tabData || {
+    runs: [],
+    testMap: {},
+    comments: {},
+    statuses: {},
+  };
+
+  if (runIds) {
+    runRows = runs.map(run => {
+      const rows = testMap[run.id];
+
+      return (
+        <RunRow
+          key={`run-${run.id}`}
+          run={run}
+          rows={rows}
+          comments={comments}
+          statuses={statuses}
+          record={record}
+          domain={domain}
+        />
+      );
+    });
+  }
+
+  return (
+    <>
+      <Styles />
+      {syncData && syncData.state === SyncState.Timeout && (
+        <div className='mb-5'>
+          <aha-alert type='danger' dismissable>
+            API rate limit reached. Please try again in a few minutes
+          </aha-alert>
+        </div>
+      )}
+
+      <div className='tab-header'>
+        <div className='tab-header-left'>
+          <div className='h-400'>Test runs</div>
+          <aha-button
+            kind='secondary'
+            onClick={() => setLinkRunModalOpen(true)}
+          >
+            <aha-icon icon='fa-regular fa-link' />
+            Link a test run
+          </aha-button>
+        </div>
+        {linkRunModalOpen && (
+          <LinkTestRun
+            record={record}
+            runIds={runIds}
+            syncData={syncData}
+            onClose={() => setLinkRunModalOpen(false)}
+          />
+        )}
+        <div className='tab-header-right'>
+          {syncData && (
+            <>
+              <span className='text-small text-light'>
+                Last updated: {timeAgo(syncData.lastSync)}
+              </span>
+              {syncData.state === SyncState.Errored && (
+                <span className='text-small text-light text-error'>
+                  Failed to sync
+                </span>
+              )}
+              <aha-button
+                onClick={() =>
+                  waitForBulkSync({
+                    domain,
+                    syncDelay: 0,
+                    setState: setSyncData,
+                    reload: reloadTabData,
+                  })
+                }
+                disabled={syncData.state === SyncState.Running ? true : null}
+                size='mini'
+                kind='link'
+              >
+                {syncData.state === SyncState.Running
+                  ? 'Refreshing'
+                  : 'Refresh'}
+              </aha-button>
+            </>
+          )}
+        </div>
+      </div>
+      <div className='run-rows'>
+        {loading ? <aha-loading-row rows={5} columns={2} /> : runRows}
+      </div>
+    </>
+  );
+};
+
+export default SprintTab;

--- a/src/components/tabs/TestRow.tsx
+++ b/src/components/tabs/TestRow.tsx
@@ -14,7 +14,8 @@ type RowProps = {
   status?: Status;
   domain: string;
   record: ExtensionRecord;
-  syncData: BulkSyncState;
+  syncData?: BulkSyncState;
+  canDelete?: boolean;
 };
 
 const TestRow: React.FC<RowProps> = ({
@@ -25,6 +26,7 @@ const TestRow: React.FC<RowProps> = ({
   domain,
   record,
   syncData,
+  canDelete = true,
 }) => {
   const [linkTestModalOpen, setLinkTestModalOpen] = useState(false);
 
@@ -54,7 +56,10 @@ const TestRow: React.FC<RowProps> = ({
             )}
             <RecordLink record={test} domain={domain} />
             {status && (
-              <aha-pill color={numberToColor(status.colorMedium)}>
+              <aha-pill
+                class='test-status'
+                color={numberToColor(status.colorMedium)}
+              >
                 {status.label}
               </aha-pill>
             )}
@@ -79,9 +84,11 @@ const TestRow: React.FC<RowProps> = ({
             )}
           </>
         )}
-        <aha-button size='mini' kind='icon' onClick={unlink}>
-          <aha-icon icon='fa-regular fa-trash-can' />
-        </aha-button>
+        {canDelete && (
+          <aha-button size='mini' kind='icon' onClick={unlink}>
+            <aha-icon icon='fa-regular fa-trash-can' />
+          </aha-button>
+        )}
       </div>
     </div>
   );

--- a/src/events/syncRuns.ts
+++ b/src/events/syncRuns.ts
@@ -92,6 +92,7 @@ const syncTestRuns: (props: SyncTestRunsProps) => void = async ({
       suiteId: testRun.suite_id,
       name: truncate(testRun.name),
       createdOn: testRun.created_on,
+      completed: completed === 1,
     })) as TestRun[];
 
     const hasMore = json['_links']?.next !== null;

--- a/src/events/syncRunsForPlan.ts
+++ b/src/events/syncRunsForPlan.ts
@@ -37,6 +37,7 @@ const syncTestRunsForPlan: (props: RunsForPlanProps) => void = async ({
           suiteId: run.suite_id,
           name: truncate(run.name),
           createdOn: run.created_on,
+          completed: run.is_completed,
         });
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,6 +47,7 @@ export type TestRun = {
   suiteId: number;
   name: string;
   createdOn: number;
+  completed: boolean;
 };
 
 export type Test = {

--- a/src/lib/extensionFields/queries.ts
+++ b/src/lib/extensionFields/queries.ts
@@ -137,61 +137,34 @@ export const getRecords: <T extends TestRailRecord>(
   return result.sort((a, b) => b.id - a.id); // Sort by ID descending
 };
 
-export async function getProjectSections(
-  projectIds: number[] | undefined
-): Promise<{
-  [projectId: number]: Section[];
-}> {
+export const getProjectRecords: <T extends TestRun | TestCase | Section>(
+  projectIds: number[] | undefined,
+  kind: TestRailRecord['kind']
+) => Promise<{
+  [projectId: number]: T[];
+}> = async <T extends TestRun | TestCase | Section>(projectIds, kind) => {
   if (!projectIds || projectIds.length === 0) return {};
 
-  const mapping: { [projectId: number]: Section[] } = {};
+  const mapping: { [projectId: number]: T[] } = {};
 
   const keys = projectIds.map(projectId =>
-    indexKeyForKindAndParent('Section', projectId)
+    indexKeyForKindAndParent(kind, projectId)
   );
 
-  const sectionIds = (await getAccountExtensionFields<number[]>(keys)).flat();
+  const ids = (await getAccountExtensionFields<number[]>(keys)).flat();
 
-  const sections = await getRecords<Section>(sectionIds, 'Section');
+  const records = await getRecords<T>(ids, kind);
 
-  for (const section of sections) {
-    if (!mapping[section.projectId]) {
-      mapping[section.projectId] = [];
+  for (const record of records) {
+    if (!mapping[record.projectId]) {
+      mapping[record.projectId] = [];
     }
 
-    mapping[section.projectId].push(section);
+    mapping[record.projectId].push(record);
   }
 
   return mapping;
-}
-
-export async function getProjectTestCases(
-  projectIds: number[] | undefined
-): Promise<{
-  [projectId: number]: TestCase[];
-}> {
-  if (!projectIds || projectIds.length === 0) return {};
-
-  const mapping: { [projectId: number]: TestCase[] } = {};
-
-  const keys = projectIds.map(projectId =>
-    indexKeyForKindAndParent('TestCase', projectId)
-  );
-
-  const caseIds = (await getAccountExtensionFields<number[]>(keys)).flat();
-
-  const cases = await getRecords<TestCase>(caseIds, 'TestCase');
-
-  for (const testCase of cases) {
-    if (!mapping[testCase.projectId]) {
-      mapping[testCase.projectId] = [];
-    }
-
-    mapping[testCase.projectId].push(testCase);
-  }
-
-  return mapping;
-}
+};
 
 export async function getLinkedComments(
   tests: Test[]
@@ -263,3 +236,42 @@ export async function getAllRunIds(): Promise<number[]> {
 
   return runs.map(run => run.id);
 }
+
+export const getRunRowData: (
+  runIds: undefined | number[]
+) => Promise<
+  [{ [runId: number]: [TestCase, Test][] }, Test[]]
+> = async runIds => {
+  if (!runIds) return [{}, []];
+
+  const testKeys = runIds.map(runId => indexKeyForKindAndParent('Test', runId));
+  const testIds = (await getAccountExtensionFields<number[]>(testKeys)).flat();
+  const tests = await getRecords<Test>(testIds, 'Test');
+
+  const caseKeys = tests.map(test => fieldName('TestCase', test.caseId));
+  const testCases = await getAccountExtensionFields<TestCase>(caseKeys);
+
+  const testCaseMap = testCases.reduce((acc, testCase) => {
+    acc[testCase.id] = testCase;
+    return acc;
+  }, {});
+
+  const testMap = tests.reduce(
+    (acc: { [runId: number]: [TestCase, Test][] }, test) => {
+      if (!acc[test.runId]) {
+        acc[test.runId] = [];
+      }
+
+      const testCase = testCaseMap[test.caseId];
+
+      if (!testCase) return acc;
+
+      acc[test.runId].push([testCase, test]);
+
+      return acc;
+    },
+    {}
+  );
+
+  return [testMap, tests];
+};

--- a/src/lib/extensionFields/updates.ts
+++ b/src/lib/extensionFields/updates.ts
@@ -1,4 +1,9 @@
-import { IDENTIFIER, TestRailRecord, TestResult } from '../../extension';
+import {
+  IDENTIFIER,
+  TestRailRecord,
+  TestRun,
+  TestResult,
+} from '../../extension';
 import { ExtensionRecord } from '../extensionRecord';
 import {
   fieldName,
@@ -54,23 +59,24 @@ export const saveRecords: <T extends TestRailRecord>(
   await updateRecordIndexes(records);
 };
 
-export const saveNewRecords: <T extends TestRailRecord>(
-  records: T[]
-) => Promise<T[]> = async <T extends TestRailRecord>(records) => {
+export const saveNewRuns: (
+  records: TestRun[]
+) => Promise<TestRun[]> = async records => {
   if (records.length === 0) return [];
 
   const newRecords = [];
 
   const keys = records.map(record => fieldName(record.kind, record.id));
-  const map = await getAccountExtensionFieldMap<T>(keys);
+  const map = await getAccountExtensionFieldMap<TestRun>(keys);
 
+  // Once a run is completed it no longer changes and can be ignored
   for (const record of records) {
-    if (map[fieldName(record.kind, record.id)]) continue;
+    if (map[fieldName(record.kind, record.id)]?.completed) continue;
 
     newRecords.push(record);
   }
 
-  await saveRecords<T>(newRecords);
+  await saveRecords<TestRun>(newRecords);
 
   return newRecords;
 };

--- a/src/lib/sync/syncPlans.ts
+++ b/src/lib/sync/syncPlans.ts
@@ -4,7 +4,7 @@ import {
   waitForPagedLambda,
   waitForIndexedLambda,
 } from './interface';
-import { saveRecords, saveNewRecords } from '../extensionFields/updates';
+import { saveRecords, saveNewRuns } from '../extensionFields/updates';
 
 // We don't want to fetch more than a page of completed plans, to avoid loading up on historic data.
 const NUM_COMPLETED_PLANS = 250;
@@ -149,7 +149,7 @@ const syncRunsForPlan: (props: SyncRunProps) => Promise<TestRun[]> = async ({
 
   // When syncing completed plans, only save new records to reduce syncing effort.
   if (completed) {
-    runs = await saveNewRecords<TestRun>(runs);
+    runs = await saveNewRuns(runs);
   } else {
     await saveRecords<TestRun>(runs);
   }

--- a/src/lib/sync/syncRuns.ts
+++ b/src/lib/sync/syncRuns.ts
@@ -4,7 +4,7 @@ import {
   waitForPagedLambda,
   waitForIndexedLambda,
 } from './interface';
-import { saveRecords, saveNewRecords } from '../extensionFields/updates';
+import { saveRecords, saveNewRuns } from '../extensionFields/updates';
 
 // We don't want to fetch more than a page of completed runs per project, to avoid loading up on historic data.
 const NUM_COMPLETED_RUNS = 250;
@@ -98,7 +98,7 @@ export const syncCompletedRuns: (
 
   logger('Saving completed test runs to Aha!');
 
-  const newRuns = await saveNewRecords<TestRun>(completedRuns);
+  const newRuns = await saveNewRuns(completedRuns);
 
   await aha.account.setExtensionField(IDENTIFIER, 'lastCompletedRunSync', now);
   logger('Successfully saved all completed test runs');

--- a/src/views/tests.tsx
+++ b/src/views/tests.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
-
 import FeatureTab from '../components/tabs/FeatureTab';
+import SprintTab from '../components/tabs/SprintTab';
 import { isExtensionRecord } from '../lib/extensionRecord';
 
 aha.on('tests', ({ record, fields }, { settings }) => {
   if (!isExtensionRecord(record)) return null;
+
+  if (record.typename === 'Iteration') {
+    return <SprintTab record={record} fields={fields} settings={settings} />;
+  }
 
   return <FeatureTab record={record} fields={fields} settings={settings} />;
 });


### PR DESCRIPTION
SearchByName now supports nested unselectable headers (for the Open/Completed Run headers), fixed bug that was re-queuing bulk sync when linked records changed, and removes unnecessary loads of linked caseIds from SelectTestCase