### PR TITLE
Link features to runs

### DIFF
--- a/src/components/tabs/FeatureTab.tsx
+++ b/src/components/tabs/FeatureTab.tsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import { TestCase, Test, Status } from '../../extension';
+import { TestCase, TestRun, Test, Status } from '../../extension';
 import {
   getRecords,
   getLinkedComments,
+  getRunRowData,
 } from '../../lib/extensionFields/queries';
 import { timeAgo } from '../../lib/util';
 import { Styles } from '../Styles';
+import LinkTestRun from '../modals/LinkTestRun';
 import LinkTestCase from '../modals/LinkTestCase';
 import LinkTest from '../modals/LinkTest';
 import CreateTestCase from '../modals/CreateTestCase';
@@ -13,6 +15,7 @@ import { ExtensionRecord } from '../../lib/extensionRecord';
 import { BulkSyncState, SyncState } from '../../lib/sync/bulkSync';
 import waitForBulkSync from '../../lib/sync/waitForBulkSync';
 import TestRow from './TestRow';
+import RunRow from './RunRow';
 
 type TabProps = {
   record: ExtensionRecord;
@@ -20,29 +23,43 @@ type TabProps = {
   settings: Aha.Settings;
 };
 
+type TestMap = { [runId: number]: [TestCase, Test][] };
+
 type FeatureTabData = {
   testCases: TestCase[];
   tests: { [caseId: number]: Test };
   comments: { [testId: number]: { timestamp: number; comment: string } };
   statuses: { [key: string]: Status };
+  runs: TestRun[];
+  runTestMap: TestMap;
 };
 
 const getFeatureTabData: (
   caseIds: number[],
+  runIds: number[],
   testIds: number[]
-) => Promise<FeatureTabData> = async (caseIds, testIds) => {
+) => Promise<FeatureTabData> = async (caseIds, runIds, testIds) => {
   const testCases = await getRecords<TestCase>(caseIds, 'TestCase');
-  const tests = await getRecords<Test>(testIds, 'Test');
+  const runs = await getRecords<TestRun>(runIds, 'TestRun');
+  const linkedTests = await getRecords<Test>(testIds, 'Test');
 
-  const testMap = tests.reduce(
+  const testMap = linkedTests.reduce(
     (acc, test) => ({ ...acc, [test.caseId]: test }),
     {}
   );
 
-  const commentMap = await getLinkedComments(tests);
+  const [runTestMap, runTests] = await getRunRowData(runIds);
 
-  const statusIds = tests.map(test => test.statusId);
-  const statuses = await getRecords<Status>(statusIds, 'Status');
+  const testIdSet = new Set(runTests.map(test => test.id));
+  const statusIds = new Set(runTests.map(test => test.statusId));
+
+  for (const test of linkedTests) {
+    testIdSet.add(test.id);
+    statusIds.add(test.statusId);
+  }
+
+  const commentMap = await getLinkedComments([...testIdSet]);
+  const statuses = await getRecords<Status>([...statusIds], 'Status');
   const statusMap = statuses.reduce((acc, status) => {
     acc[status.id] = status;
     return acc;
@@ -50,6 +67,8 @@ const getFeatureTabData: (
 
   return {
     testCases,
+    runs,
+    runTestMap,
     tests: testMap,
     comments: commentMap,
     statuses: statusMap,
@@ -58,12 +77,14 @@ const getFeatureTabData: (
 
 const FeatureTab: React.FC<TabProps> = ({ record, fields, settings }) => {
   const caseIds = fields['caseIds'] as number[] | undefined;
+  const runIds = fields['runIds'] as number[] | undefined;
   const testIds = fields['testIds'] as number[] | undefined;
 
   const [loading, setLoading] = useState(true);
   const [syncData, setSyncData] = useState<BulkSyncState>(null);
   const [tabData, setTabData] = useState<FeatureTabData>(null);
 
+  const [linkRunModalOpen, setLinkRunModalOpen] = useState(false);
   const [linkCaseModalOpen, setLinkCaseModalOpen] = useState(false);
   const [linkTestModalOpen, setLinkTestModalOpen] = useState(false);
   const [createCaseModalOpen, setCreateCaseModalOpen] = useState(false);
@@ -80,14 +101,14 @@ const FeatureTab: React.FC<TabProps> = ({ record, fields, settings }) => {
 
   useEffect(() => {
     const initData = async () => {
-      const tabData = await getFeatureTabData(caseIds, testIds);
+      const tabData = await getFeatureTabData(caseIds, runIds, testIds);
 
       setTabData(tabData);
       setLoading(false);
     };
 
     initData();
-  }, [caseIds, testIds, reload]);
+  }, [caseIds, runIds, testIds, reload]);
 
   useEffect(() => {
     waitForBulkSync({
@@ -99,13 +120,17 @@ const FeatureTab: React.FC<TabProps> = ({ record, fields, settings }) => {
   }, []);
 
   let caseRows = null;
+  let runRows = null;
 
-  const { testCases, tests, comments, statuses } = tabData || {
-    testCases: [],
-    tests: {},
-    comments: {},
-    statuses: {},
-  };
+  const { testCases, runs, runTestMap, tests, comments, statuses } =
+    tabData || {
+      testCases: [],
+      runs: [],
+      runTestMap: {},
+      tests: {},
+      comments: {},
+      statuses: {},
+    };
 
   if (caseIds) {
     caseRows = testCases.map(testCase => {
@@ -123,6 +148,24 @@ const FeatureTab: React.FC<TabProps> = ({ record, fields, settings }) => {
           record={record}
           domain={domain}
           syncData={syncData}
+        />
+      );
+    });
+  }
+
+  if (runIds) {
+    runRows = runs.map(run => {
+      const rows = runTestMap[run.id] ?? [];
+
+      return (
+        <RunRow
+          key={`run-${run.id}`}
+          run={run}
+          rows={rows}
+          comments={comments}
+          statuses={statuses}
+          record={record}
+          domain={domain}
         />
       );
     });
@@ -149,6 +192,12 @@ const FeatureTab: React.FC<TabProps> = ({ record, fields, settings }) => {
             </aha-button>
             <aha-menu-content>
               <aha-menu-item>
+                <a onClick={() => setLinkRunModalOpen(true)}>
+                  <aha-icon icon='fa-regular fa-link' />
+                  Link a test run
+                </a>
+              </aha-menu-item>
+              <aha-menu-item>
                 <a onClick={() => setLinkTestModalOpen(true)}>
                   <aha-icon icon='fa-regular fa-link' />
                   Link a test
@@ -170,6 +219,14 @@ const FeatureTab: React.FC<TabProps> = ({ record, fields, settings }) => {
             Create a test case
           </aha-button>
         </div>
+        {linkRunModalOpen && (
+          <LinkTestRun
+            record={record}
+            runIds={runIds}
+            syncData={syncData}
+            onClose={() => setLinkRunModalOpen(false)}
+          />
+        )}
         {linkCaseModalOpen && (
           <LinkTestCase
             record={record}
@@ -226,7 +283,16 @@ const FeatureTab: React.FC<TabProps> = ({ record, fields, settings }) => {
           )}
         </div>
       </div>
-      <div>{loading ? <aha-loading-row rows={5} columns={2} /> : caseRows}</div>
+      {loading ? (
+        <div>
+          <aha-loading-row rows={5} columns={2} />
+        </div>
+      ) : (
+        <>
+          <div className='run-rows mb-3'>{runRows}</div>
+          <div>{caseRows}</div>
+        </>
+      )}
     </>
   );
 };

--- a/src/components/tabs/SprintTab.tsx
+++ b/src/components/tabs/SprintTab.tsx
@@ -34,7 +34,7 @@ const getSprintTabData: (
   const runs = await getRecords<TestRun>(runIds, 'TestRun');
   const [testMap, tests] = await getRunRowData(runIds);
 
-  const commentMap = await getLinkedComments(tests);
+  const commentMap = await getLinkedComments(tests.map(test => test.id));
 
   const statusIds = tests.map(test => test.statusId);
   const statuses = await getRecords<Status>(statusIds, 'Status');

--- a/src/lib/extensionFields/queries.test.ts
+++ b/src/lib/extensionFields/queries.test.ts
@@ -292,10 +292,7 @@ describe('getLinkedComments', () => {
   });
 
   it('maps comments to test IDs correctly', async () => {
-    const tests: Test[] = [
-      { id: 1, kind: 'Test', caseId: 1, runId: 1, statusId: 1 },
-      { id: 2, kind: 'Test', caseId: 2, runId: 2, statusId: 1 },
-    ];
+    const ids = [1, 2];
 
     const mockComments = {
       test_1_comment: { timestamp: 123, comment: 'Comment 1' },
@@ -307,7 +304,7 @@ describe('getLinkedComments', () => {
       { name: 'test_2_comment', value: mockComments['test_2_comment'] },
     ]);
 
-    const result = await getLinkedComments(tests);
+    const result = await getLinkedComments(ids);
 
     expect(result).toEqual({
       1: mockComments['test_1_comment'],

--- a/src/lib/extensionFields/queries.ts
+++ b/src/lib/extensionFields/queries.ts
@@ -171,22 +171,22 @@ export const getProjectSuiteMapping: (
   return projectSuites;
 };
 
-export const getLinkedComments: (tests: Test[]) => Promise<{
+export const getLinkedComments: (ids: number[]) => Promise<{
   [testId: number]: { comment: string; timestamp: number };
-}> = async tests => {
-  const commentKey = test => `${fieldName('Test', test.id)}_comment`;
+}> = async ids => {
+  const commentKey = id => `${fieldName('Test', id)}_comment`;
 
-  const keys = tests.map(test => commentKey(test));
+  const keys = ids.map(id => commentKey(id));
 
   const commentLinks = await getAccountExtensionFieldMap<{
     timestamp: number;
     comment: string;
   }>(keys);
 
-  return tests.reduce(
-    (result, test, i) => ({
+  return ids.reduce(
+    (result, id) => ({
       ...result,
-      [test.id]: commentLinks[commentKey(test)],
+      [id]: commentLinks[commentKey(id)],
     }),
     {}
   );

--- a/src/lib/extensionFields/updates.test.ts
+++ b/src/lib/extensionFields/updates.test.ts
@@ -16,7 +16,6 @@ const mockSetExtensionFields = jest.fn();
 (global as any).aha = {
   account: {
     getExtensionField: mockGetExtensionField,
-    setExtensionField: mockSetExtensionField,
     setExtensionFields: mockSetExtensionFields,
   },
 };
@@ -24,7 +23,6 @@ const mockSetExtensionFields = jest.fn();
 const mockRecord = {
   getExtensionField: mockGetExtensionField,
   setExtensionField: mockSetExtensionField,
-  setExtensionFields: mockSetExtensionFields,
 } as unknown as ExtensionRecord;
 
 jest.mock('./queryExtensionFields', () => ({
@@ -109,10 +107,12 @@ describe('unlinkRecord', () => {
 describe('saveRecords', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetExtensionField.mockResolvedValue([3, 4]);
+    mockGetExtensionMap.mockResolvedValue({
+      project_100_caseIds: [3, 4],
+    });
   });
 
-  it('saves records and updates the appropriate index', async () => {
+  it('saves records and updates the appropriate indices', async () => {
     const records: TestCase[] = [
       {
         kind: 'TestCase',
@@ -125,8 +125,8 @@ describe('saveRecords', () => {
       {
         kind: 'TestCase',
         id: 2,
-        projectId: 100,
-        suiteId: 1,
+        projectId: 200,
+        suiteId: 2,
         title: 'Case 2',
         createdOn: 0,
       },
@@ -134,21 +134,19 @@ describe('saveRecords', () => {
 
     await saveRecords(records);
 
-    expect(mockSetExtensionFields).toHaveBeenCalledWith(IDENTIFIER, {
+    expect(mockSetExtensionFields).toHaveBeenNthCalledWith(1, IDENTIFIER, {
       case_1: records[0],
       case_2: records[1],
     });
 
-    expect(mockSetExtensionField).toHaveBeenCalledWith(
-      IDENTIFIER,
-      'project_100_caseIds',
-      [3, 4, 1, 2]
-    );
+    expect(mockSetExtensionFields).toHaveBeenNthCalledWith(2, IDENTIFIER, {
+      project_100_caseIds: [3, 4, 1],
+      project_200_caseIds: [2],
+    });
   });
 
   it('does nothing with empty records array', async () => {
     await saveRecords([]);
-    expect(mockSetExtensionField).not.toHaveBeenCalled();
     expect(mockSetExtensionFields).not.toHaveBeenCalled();
   });
 });
@@ -156,7 +154,6 @@ describe('saveRecords', () => {
 describe('saveNewRuns', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetExtensionField.mockResolvedValue([3, 4]);
   });
 
   it('saves only non-completed runs', async () => {
@@ -181,9 +178,13 @@ describe('saveNewRuns', () => {
       },
     ];
 
-    mockGetExtensionMap.mockResolvedValue({
+    mockGetExtensionMap.mockResolvedValueOnce({
       run_1: { completed: false },
       run_2: { completed: true },
+    });
+
+    mockGetExtensionMap.mockResolvedValueOnce({
+      project_100_runIds: [3, 4],
     });
 
     const result = await saveNewRuns(runs);
@@ -191,22 +192,19 @@ describe('saveNewRuns', () => {
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe(1);
 
-    expect(mockSetExtensionFields).toHaveBeenCalledWith(IDENTIFIER, {
+    expect(mockSetExtensionFields).toHaveBeenNthCalledWith(1, IDENTIFIER, {
       run_1: runs[0],
     });
 
-    expect(mockSetExtensionField).toHaveBeenCalledWith(
-      IDENTIFIER,
-      'project_100_runIds',
-      [3, 4, 1]
-    );
+    expect(mockSetExtensionFields).toHaveBeenNthCalledWith(2, IDENTIFIER, {
+      project_100_runIds: [3, 4, 1],
+    });
   });
 
   it('returns empty array for empty input', async () => {
     const result = await saveNewRuns([]);
 
     expect(result).toEqual([]);
-    expect(mockSetExtensionField).not.toHaveBeenCalled();
     expect(mockSetExtensionFields).not.toHaveBeenCalled();
   });
 });
@@ -240,7 +238,6 @@ describe('linkResultsToTests', () => {
 
     await linkResultsToTests(results);
 
-    expect(mockSetExtensionField).not.toHaveBeenCalled();
     expect(mockSetExtensionFields).toHaveBeenCalledWith(IDENTIFIER, {
       test_100_comment: { timestamp: 200, comment: 'Second' },
     });

--- a/src/lib/extensionFields/updates.test.ts
+++ b/src/lib/extensionFields/updates.test.ts
@@ -11,17 +11,20 @@ import {
 
 const mockGetExtensionField = jest.fn();
 const mockSetExtensionField = jest.fn();
+const mockSetExtensionFields = jest.fn();
 
 (global as any).aha = {
   account: {
     getExtensionField: mockGetExtensionField,
     setExtensionField: mockSetExtensionField,
+    setExtensionFields: mockSetExtensionFields,
   },
 };
 
 const mockRecord = {
   getExtensionField: mockGetExtensionField,
   setExtensionField: mockSetExtensionField,
+  setExtensionFields: mockSetExtensionFields,
 } as unknown as ExtensionRecord;
 
 jest.mock('./queryExtensionFields', () => ({
@@ -131,17 +134,10 @@ describe('saveRecords', () => {
 
     await saveRecords(records);
 
-    expect(mockSetExtensionField).toHaveBeenCalledWith(
-      IDENTIFIER,
-      'case_1',
-      records[0]
-    );
-
-    expect(mockSetExtensionField).toHaveBeenCalledWith(
-      IDENTIFIER,
-      'case_2',
-      records[1]
-    );
+    expect(mockSetExtensionFields).toHaveBeenCalledWith(IDENTIFIER, {
+      case_1: records[0],
+      case_2: records[1],
+    });
 
     expect(mockSetExtensionField).toHaveBeenCalledWith(
       IDENTIFIER,
@@ -153,6 +149,7 @@ describe('saveRecords', () => {
   it('does nothing with empty records array', async () => {
     await saveRecords([]);
     expect(mockSetExtensionField).not.toHaveBeenCalled();
+    expect(mockSetExtensionFields).not.toHaveBeenCalled();
   });
 });
 
@@ -194,11 +191,9 @@ describe('saveNewRuns', () => {
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe(1);
 
-    expect(mockSetExtensionField).toHaveBeenCalledWith(
-      IDENTIFIER,
-      'run_1',
-      runs[0]
-    );
+    expect(mockSetExtensionFields).toHaveBeenCalledWith(IDENTIFIER, {
+      run_1: runs[0],
+    });
 
     expect(mockSetExtensionField).toHaveBeenCalledWith(
       IDENTIFIER,
@@ -212,6 +207,7 @@ describe('saveNewRuns', () => {
 
     expect(result).toEqual([]);
     expect(mockSetExtensionField).not.toHaveBeenCalled();
+    expect(mockSetExtensionFields).not.toHaveBeenCalled();
   });
 });
 
@@ -244,11 +240,10 @@ describe('linkResultsToTests', () => {
 
     await linkResultsToTests(results);
 
-    expect(mockSetExtensionField).toHaveBeenCalledWith(
-      IDENTIFIER,
-      'test_100_comment',
-      { timestamp: 200, comment: 'Second' }
-    );
+    expect(mockSetExtensionField).not.toHaveBeenCalled();
+    expect(mockSetExtensionFields).toHaveBeenCalledWith(IDENTIFIER, {
+      test_100_comment: { timestamp: 200, comment: 'Second' },
+    });
   });
 
   it('does not update when existing comment is more recent', async () => {
@@ -268,6 +263,6 @@ describe('linkResultsToTests', () => {
 
     await linkResultsToTests(results);
 
-    expect(mockSetExtensionField).not.toHaveBeenCalled();
+    expect(mockSetExtensionFields).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/extensionFields/updates.ts
+++ b/src/lib/extensionFields/updates.ts
@@ -48,14 +48,13 @@ export const saveRecords: <T extends TestRailRecord>(
 ) => Promise<void> = async records => {
   if (records.length === 0) return;
 
+  const fieldsToSave = {};
+
   for (const record of records) {
-    await aha.account.setExtensionField(
-      IDENTIFIER,
-      fieldName(record.kind, record.id),
-      record
-    );
+    fieldsToSave[fieldName(record.kind, record.id)] = record;
   }
 
+  await aha.account.setExtensionFields(IDENTIFIER, fieldsToSave);
   await updateRecordIndexes(records);
 };
 
@@ -135,6 +134,9 @@ export const linkResultsToTests = async (results: TestResult[]) => {
     comment: string;
   }>(Object.keys(keyMap));
 
+  const fields = {};
+  let shouldUpdate = false;
+
   for (const key in keyMap) {
     let best = commentLinks[key];
     let unchanged = true;
@@ -153,6 +155,10 @@ export const linkResultsToTests = async (results: TestResult[]) => {
 
     if (unchanged) continue;
 
-    await aha.account.setExtensionField(IDENTIFIER, key, best);
+    shouldUpdate = true;
+    fields[key] = best;
   }
+
+  if (!shouldUpdate) return;
+  await aha.account.setExtensionFields(IDENTIFIER, fields);
 };

--- a/src/lib/extensionFields/updates.ts
+++ b/src/lib/extensionFields/updates.ts
@@ -11,6 +11,8 @@ import {
   getAccountExtensionFieldMap,
 } from './queries';
 
+const MAX_FIELDS_PER_SAVE = 500;
+
 export const linkRecord: (
   record: ExtensionRecord,
   id: number,
@@ -48,13 +50,13 @@ export const saveRecords: <T extends TestRailRecord>(
 ) => Promise<void> = async records => {
   if (records.length === 0) return;
 
-  const fieldsToSave = {};
+  const fields = [];
 
   for (const record of records) {
-    fieldsToSave[fieldName(record.kind, record.id)] = record;
+    fields.push([fieldName(record.kind, record.id), record]);
   }
 
-  await aha.account.setExtensionFields(IDENTIFIER, fieldsToSave);
+  await saveChunked(fields);
   await updateRecordIndexes(records);
 };
 
@@ -95,25 +97,20 @@ const updateRecordIndexes: <T extends TestRailRecord>(
     keyMap[indexKey].push(record);
   }
 
-  for (const key in keyMap) {
-    await updateIndex(key, keyMap[key]);
-  }
-};
-
-const updateIndex: <T extends TestRailRecord>(
-  key: string,
-  records: T[]
-) => Promise<void> = async (key, records) => {
-  const allIds =
-    (await aha.account.getExtensionField<number[]>(IDENTIFIER, key)) ?? [];
-
-  allIds.push(...records.map(record => record.id));
-
-  await aha.account.setExtensionField(
-    IDENTIFIER,
-    key,
-    Array.from(new Set(allIds))
+  const existingIndexes = await getAccountExtensionFieldMap<number[]>(
+    Object.keys(keyMap)
   );
+
+  const fields = [];
+
+  for (const key in keyMap) {
+    let allIds = existingIndexes[key] ?? [];
+    allIds.push(...keyMap[key].map(record => record.id));
+
+    fields.push([key, Array.from(new Set(allIds))]);
+  }
+
+  await saveChunked(fields);
 };
 
 export const linkResultsToTests = async (results: TestResult[]) => {
@@ -134,7 +131,7 @@ export const linkResultsToTests = async (results: TestResult[]) => {
     comment: string;
   }>(Object.keys(keyMap));
 
-  const fields = {};
+  const fields: [string, { timestamp: number; comment: string }][] = [];
   let shouldUpdate = false;
 
   for (const key in keyMap) {
@@ -156,9 +153,21 @@ export const linkResultsToTests = async (results: TestResult[]) => {
     if (unchanged) continue;
 
     shouldUpdate = true;
-    fields[key] = best;
+    fields.push([key, best]);
   }
 
   if (!shouldUpdate) return;
-  await aha.account.setExtensionFields(IDENTIFIER, fields);
+
+  await saveChunked(fields);
+};
+
+const saveChunked: (
+  fields: [string, any][]
+) => Promise<void> = async fields => {
+  for (let i = 0; i < fields.length; i += MAX_FIELDS_PER_SAVE) {
+    const chunk = fields.slice(i, i + MAX_FIELDS_PER_SAVE);
+    const chunkFields = Object.fromEntries(chunk);
+
+    await aha.account.setExtensionFields(IDENTIFIER, chunkFields);
+  }
 };


### PR DESCRIPTION
Performance improvements using the new `setExtensionFields` functionality - should drastically reduce the number of GQL calls that need to be made when many records need to be saved, and be less susceptible to network flakiness.

Also allows features to be linked to test runs. When merged, this will be version 1.2.0.