### PR TITLE
Fix bug incorrectly joining truncated strings

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -13,7 +13,7 @@ export const truncate: (text: string) => string = text => {
 
   // Using [...text] means we can slice by character, not by byte (still fails with zero-width separators)
   return text.length > MAX_LENGTH
-    ? [...text].slice(0, MAX_LENGTH) + '...'
+    ? [...text].slice(0, MAX_LENGTH).join('') + '...'
     : text;
 };
 


### PR DESCRIPTION
When the code was changed to support multi-byte characters, introduced a bug where the string was turned into an array before calling `+ '...'` which caused it to join, adding commas between every character.

Screenshot below shows correct behaviour with fixed truncate method

![Screenshot 2025-04-04 at 10 28 15 AM](https://github.com/user-attachments/assets/44322ad6-197f-4e64-84f0-1a9eead7e2c5)
