### PR TITLE
Correctly handle ExtensionField pagination

### DIFF
--- a/src/lib/extensionFields/queryExtensionFields.ts
+++ b/src/lib/extensionFields/queryExtensionFields.ts
@@ -7,22 +7,15 @@ const GQL_BATCH_SIZE = 500;
 const queryExtensionFields: (
   names: string[]
 ) => Promise<Aha.ExtensionField[]> = async (names: string[]) => {
-  const results: Aha.ExtensionField[] = [];
-
-  for (let i = 0; i < names.length; i += GQL_BATCH_SIZE) {
-    const chunk = names.slice(i, i + GQL_BATCH_SIZE);
-
-    const result = await aha.models.ExtensionField.select('name', 'value')
-      .where({
-        names: chunk,
-        extensionIdentifier: IDENTIFIER,
-        extensionFieldableType: 'ACCOUNT',
-        extensionFieldableId: aha.account.id,
-      })
-      .all();
-
-    results.push(...result);
-  }
+  const results = await aha.models.ExtensionField.select('name', 'value')
+    .where({
+      names: names,
+      extensionIdentifier: IDENTIFIER,
+      extensionFieldableType: 'ACCOUNT',
+      extensionFieldableId: aha.account.id,
+    })
+    .per(GQL_BATCH_SIZE)
+    .findInBatches();
 
   return results;
 };


### PR DESCRIPTION
Incorrect use of `.all()`, which only returns a single page. Changes the code to use `findInBatches()`, which chunks automatically - also ensures the page size fetched is 500 records.