### PR TITLE
Ensure queryExtensionFields handles blank names array

### DIFF
--- a/src/lib/extensionFields/queryExtensionFields.ts
+++ b/src/lib/extensionFields/queryExtensionFields.ts
@@ -7,6 +7,8 @@ const GQL_BATCH_SIZE = 500;
 const queryExtensionFields: (
   names: string[]
 ) => Promise<Aha.ExtensionField[]> = async (names: string[]) => {
+  if (!names || names.length === 0) return [];
+
   const results = await aha.models.ExtensionField.select('name', 'value')
     .where({
       names: names,


### PR DESCRIPTION
More hangover from changing the fetching mechanism in queryExtensionFields - an empty array is an invalid parameter, which wasn't the case before.
