### PR TITLE
Update suite syncing to support paginated suites

### DIFF
--- a/src/events/syncSuites.ts
+++ b/src/events/syncSuites.ts
@@ -4,6 +4,7 @@ import { truncate } from '../lib/util';
 
 type SuiteProps = BaseParams & {
   projectId: string;
+  page?: number;
 };
 
 // Although some projects only have a single suite, we still fetch them
@@ -13,38 +14,41 @@ const syncSuites: (props: SuiteProps) => void = async ({
   record,
   eventKey,
   projectId,
+  page,
 }) => {
   try {
-    console.log(`Beginning sync of TestRail suites for project: ${projectId}`);
+    console.log(
+      `Beginning sync of TestRail suites for project: ${projectId} page: ${page}`
+    );
+
+    const params = `&offset=${page ? (page - 1) * 250 : 0}`;
 
     const json = await fetchTestRail({
       domain,
       record,
       eventKey,
-      path: `get_suites/${projectId}`,
+      path: `get_suites/${projectId}${params}`,
     });
 
     if (!json) return; // Error already logged
 
-    const suites = [] as Suite[];
-
-    for (const suite of json) {
-      if (suite.is_completed) continue; // Skip completed (archived) suites - can't be filtered in the request
-
-      suites.push({
+    const suites: Suite[] = json.suites
+      .filter(suite => !suite.is_completed)
+      .map(suite => ({
         id: suite.id,
         kind: 'Suite',
-        name: truncate(suite.name),
         projectId: suite.project_id,
-      });
-    }
+        name: truncate(suite.name),
+      }));
+
+    const hasMore = json['_links']?.next !== null;
 
     await logResult({
       record,
       eventKey,
       error: false,
-      result: suites,
-      message: `Successfully fetched ${suites.length} suites`,
+      result: { result: suites, hasMore },
+      message: `Successfully fetched ${suites.length} test suites`,
     });
   } catch (error) {
     await logResult({
@@ -60,7 +64,13 @@ const syncSuites: (props: SuiteProps) => void = async ({
 
 aha.on(
   { event: `${IDENTIFIER}.syncSuites` },
-  async ({ domain, eventKey, projectId }) => {
-    await syncSuites({ domain, eventKey, projectId, record: aha.account });
+  async ({ domain, eventKey, projectId, page }) => {
+    await syncSuites({
+      domain,
+      eventKey,
+      projectId,
+      page,
+      record: aha.account,
+    });
   }
 );

--- a/src/lib/sync/syncCases.ts
+++ b/src/lib/sync/syncCases.ts
@@ -20,7 +20,7 @@ const syncCases: (props: SyncProps) => Promise<TestCase[]> = async ({
 
   const now = Date.now();
 
-  let eventKey = `syncCases-${Date.now()}`;
+  let eventKey = `syncCases-${now}`;
   const args = { domain };
 
   const lambdaArgs = [];

--- a/src/lib/sync/syncSuites.test.ts
+++ b/src/lib/sync/syncSuites.test.ts
@@ -1,10 +1,10 @@
 import { IDENTIFIER } from '../../extension';
-import { waitForPagedLambda } from './interface';
+import { waitForIndexedLambda } from './interface';
 import { saveRecords } from '../extensionFields/updates';
 import syncSuites from './syncSuites';
 
 jest.mock('./interface', () => ({
-  waitForPagedLambda: jest.fn(),
+  waitForIndexedLambda: jest.fn(),
 }));
 
 jest.mock('../extensionFields/updates', () => ({
@@ -19,7 +19,7 @@ const mockSetExtensionField = jest.fn();
   triggerServer: jest.fn(),
 };
 
-const mockWaitPaged = waitForPagedLambda as jest.Mock;
+const mockWaitIndexed = waitForIndexedLambda as jest.Mock;
 
 describe('syncSuites', () => {
   beforeEach(() => {
@@ -54,18 +54,16 @@ describe('syncSuites', () => {
       },
     ];
 
-    mockWaitPaged.mockResolvedValue(mockSuites);
+    mockWaitIndexed.mockResolvedValue(mockSuites);
 
     const result = await syncSuites({ domain: 'test', projectIds: [100] });
 
-    expect(waitForPagedLambda).toHaveBeenCalledWith({
+    expect(waitForIndexedLambda).toHaveBeenCalledWith({
       lambdaFunc: expect.any(Function),
+      argFunc: expect.any(Function),
       args: { domain: 'test' },
       eventKey: expect.stringContaining('syncSuites-'),
-      usePage: false,
-      isPaginated: false,
-      idKey: 'projectId',
-      ids: [100],
+      numIds: 1,
     });
 
     expect(saveRecords).toHaveBeenCalledWith(mockSuites);
@@ -94,21 +92,19 @@ describe('syncSuites', () => {
       },
     ];
 
-    mockWaitPaged.mockResolvedValue(mockSuites);
+    mockWaitIndexed.mockResolvedValue(mockSuites);
 
     const result = await syncSuites({
       domain: 'test',
       projectIds: [100, 101],
     });
 
-    expect(waitForPagedLambda).toHaveBeenCalledWith({
+    expect(waitForIndexedLambda).toHaveBeenCalledWith({
       lambdaFunc: expect.any(Function),
+      argFunc: expect.any(Function),
       args: { domain: 'test' },
       eventKey: expect.stringContaining('syncSuites-'),
-      usePage: false,
-      isPaginated: false,
-      idKey: 'projectId',
-      ids: [100, 101],
+      numIds: 2,
     });
 
     expect(saveRecords).toHaveBeenCalledWith(mockSuites);
@@ -122,7 +118,7 @@ describe('syncSuites', () => {
   });
 
   it('handles empty suite list', async () => {
-    mockWaitPaged.mockResolvedValue([]);
+    mockWaitIndexed.mockResolvedValue([]);
 
     const result = await syncSuites({ domain: 'test', projectIds: [100] });
 

--- a/src/lib/sync/syncSuites.ts
+++ b/src/lib/sync/syncSuites.ts
@@ -1,5 +1,5 @@
 import { IDENTIFIER, Suite } from '../../extension';
-import { BaseSyncProps, waitForPagedLambda } from './interface';
+import { BaseSyncProps, waitForIndexedLambda } from './interface';
 import { saveRecords } from '../extensionFields/updates';
 
 type SyncProps = BaseSyncProps & {
@@ -17,18 +17,20 @@ const syncSuites: (props: SyncProps) => Promise<Suite[]> = async ({
   const now = Date.now();
   const eventKey = `syncSuites-${now}`;
 
+  const args = { domain };
+
   const lambdaFunc = async args => {
     await aha.triggerServer(`${IDENTIFIER}.syncSuites`, args);
   };
 
-  const suites = await waitForPagedLambda<Suite>({
+  const argFunc = (index: number) => ({ projectId: projectIds[index] });
+
+  const suites = await waitForIndexedLambda<Suite>({
     lambdaFunc,
-    args: { domain },
+    args,
     eventKey,
-    usePage: false,
-    isPaginated: false,
-    idKey: 'projectId',
-    ids: projectIds,
+    argFunc,
+    numIds: projectIds.length,
   });
 
   await saveRecords<Suite>(suites);


### PR DESCRIPTION
A recent TestRail API change changed the return type of the `get_suites` endpoint, causing issues when syncing - this change updates the integration to use the new paginated type.