### PR TITLE
Add ability to ignore suites and delete ignored data

### DIFF
--- a/src/components/Styles.tsx
+++ b/src/components/Styles.tsx
@@ -331,6 +331,22 @@ export const Styles = () => {
           min-width: 62px;
           text-align: center;
         }
+
+        .chevron {
+          width: var(--spacer-4);
+        }
+
+        .ignore-section {
+          cursor: pointer;
+          display: flex;
+          gap: var(--spacer-2);
+          align-items: baseline;
+          padding-bottom: var(--spacer-3);
+        }
+
+        .ignore-button {
+          padding-bottom: var(--spacer-2);
+        }
       `}
     </style>
   );

--- a/src/components/syncRows/CompletedTestPlanRow.tsx
+++ b/src/components/syncRows/CompletedTestPlanRow.tsx
@@ -20,9 +20,16 @@ const resync: (props: ResyncProps) => Promise<void> = async ({
 
     const now = Date.now();
 
+    const ignoredSuites =
+      (await aha.account.getExtensionField<number[]>(
+        IDENTIFIER,
+        'ignoredSuites'
+      )) ?? [];
+
     await syncCompletedPlans({
       domain,
       projectIds,
+      ignoredSuiteIds: ignoredSuites,
     });
     setLastSync(now);
   } catch (error) {

--- a/src/components/syncRows/CompletedTestRunRow.tsx
+++ b/src/components/syncRows/CompletedTestRunRow.tsx
@@ -20,9 +20,16 @@ const resync: (props: ResyncProps) => Promise<void> = async ({
 
     const now = Date.now();
 
+    const ignoredSuites =
+      (await aha.account.getExtensionField<number[]>(
+        IDENTIFIER,
+        'ignoredSuites'
+      )) ?? [];
+
     await syncCompletedRuns({
       domain,
       projectIds,
+      ignoredSuiteIds: ignoredSuites,
     });
     setLastSync(now);
   } catch (error) {

--- a/src/components/syncRows/OpenTestPlanRow.tsx
+++ b/src/components/syncRows/OpenTestPlanRow.tsx
@@ -19,9 +19,16 @@ const resync: (props: ResyncProps) => Promise<void> = async ({
       )) ?? [];
     const now = Date.now();
 
+    const ignoredSuites =
+      (await aha.account.getExtensionField<number[]>(
+        IDENTIFIER,
+        'ignoredSuites'
+      )) ?? [];
+
     await syncOpenPlans({
       domain,
       projectIds,
+      ignoredSuiteIds: ignoredSuites,
     });
     await setLastSync(now);
   } catch (error) {

--- a/src/components/syncRows/OpenTestRunRow.tsx
+++ b/src/components/syncRows/OpenTestRunRow.tsx
@@ -19,9 +19,16 @@ const resync: (props: ResyncProps) => Promise<void> = async ({
       )) ?? [];
     const now = Date.now();
 
+    const ignoredSuites =
+      (await aha.account.getExtensionField<number[]>(
+        IDENTIFIER,
+        'ignoredSuites'
+      )) ?? [];
+
     await syncOpenRuns({
       domain,
       projectIds,
+      ignoredSuiteIds: ignoredSuites,
     });
     await setLastSync(now);
   } catch (error) {

--- a/src/components/syncRows/SectionRow.tsx
+++ b/src/components/syncRows/SectionRow.tsx
@@ -19,12 +19,22 @@ const resync: (props: ResyncProps) => Promise<void> = async ({
         'projectIds'
       )) ?? [];
 
-    const projectSuites = await getProjectSuiteMapping(projectIds);
+    const ignoredSuites =
+      (await aha.account.getExtensionField<number[]>(
+        IDENTIFIER,
+        'ignoredSuites'
+      )) ?? [];
+
+    const projectSuites = await getProjectSuiteMapping(
+      projectIds,
+      ignoredSuites
+    );
     const now = Date.now();
 
     await syncSections({
       domain,
       projectSuites,
+      ignoredSuiteIds: ignoredSuites,
     });
 
     await setLastSync(now);

--- a/src/components/syncRows/SuiteRow.tsx
+++ b/src/components/syncRows/SuiteRow.tsx
@@ -1,8 +1,17 @@
-import React from 'react';
-import { IDENTIFIER } from '../../extension';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { IDENTIFIER, Project, Suite } from '../../extension';
 import syncSuites from '../../lib/sync/syncSuites';
 import BaseSyncRow, { RowProps, ResyncProps } from './BaseSyncRow';
 import { showError } from '../../lib/util';
+import {
+  fieldName,
+  getAccountExtensionFieldMap,
+  getAccountExtensionFields,
+  getRecords,
+  indexKeyForKindAndParent,
+} from '../../lib/extensionFields/queries';
+import { deleteIgnoredSuiteRecords } from '../../lib/ignore';
+import { showSuccess } from '../../lib/util';
 
 const resync: (props: ResyncProps) => Promise<void> = async ({
   domain,
@@ -18,12 +27,20 @@ const resync: (props: ResyncProps) => Promise<void> = async ({
         'projectIds'
       )) ?? [];
 
+    const ignoredSuites =
+      (await aha.account.getExtensionField<number[]>(
+        IDENTIFIER,
+        'ignoredSuites'
+      )) ?? [];
+
     const now = Date.now();
 
     await syncSuites({
       domain,
       projectIds,
+      ignoredSuiteIds: ignoredSuites,
     });
+
     await setLastSync(now);
   } catch (error) {
     showError(error.message);
@@ -32,16 +49,281 @@ const resync: (props: ResyncProps) => Promise<void> = async ({
   }
 };
 
-const SuiteRow: React.FC<RowProps> = ({ domain, disabled }) => {
+const ConfirmIgnoreModal: React.FC<{
+  onClose: () => void;
+  onConfirm: () => Promise<void>;
+}> = ({ onClose, onConfirm }) => {
+  const [disabled, setDisabled] = useState(false);
+  const modalRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const modal = modalRef.current;
+    modal.addEventListener('aha-modal:close', onClose);
+
+    return () => {
+      modal.removeEventListener('aha-modal:close', onClose);
+    };
+  }, [onClose]);
+
   return (
-    <BaseSyncRow
-      recordType='Test suites'
-      resync={resync}
-      domain={domain}
-      disabled={disabled}
-      syncKey='syncingSuites'
-      lastSyncKey='lastSuiteSync'
-    />
+    <aha-modal ref={modalRef} open position='h-center' size='medium'>
+      <aha-modal-header modalTitle='Update ignored suites'>
+        Update ignored suites
+      </aha-modal-header>
+      <aha-modal-body>
+        <div>
+          Are you sure you want to update the ignored suites? This will delete
+          the ignored suites and all associated sections, test cases, and
+          results. If you remove a suite from the ignore list, a full re-sync
+          will be required to reload the data associated with that suite.
+        </div>
+      </aha-modal-body>
+      <aha-modal-footer>
+        <aha-button
+          kind='primary'
+          disabled={disabled ? true : null}
+          onClick={async () => {
+            setDisabled(true);
+            await onConfirm();
+            setDisabled(false);
+            onClose();
+          }}
+        >
+          {disabled ? 'Updating, do not leave this page...' : 'Confirm'}
+        </aha-button>
+      </aha-modal-footer>
+    </aha-modal>
+  );
+};
+
+const IgnoreSuiteRow: React.FC<{
+  setIgnoredSuites: (id: number, isIgnored: boolean) => void;
+  suite: Suite;
+  ignored: boolean;
+}> = ({ setIgnoredSuites, suite, ignored }) => {
+  return (
+    <div
+      className='search-row has-pointer'
+      onClick={() => setIgnoredSuites(suite.id, !ignored)}
+    >
+      <div className={`search-result${ignored ? ' selected' : ''}`}>
+        <div className='search-column'>
+          {ignored ? (
+            <aha-icon className='search-selected' icon='fa-solid fa-check' />
+          ) : (
+            <aha-icon icon='fa-regular fa-square' />
+          )}
+
+          <div className='search-text'>
+            <div>{suite.name}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const IgnoreSuiteProjectRow: React.FC<{
+  ignoreSuite: (id: number, isIgnored: boolean) => void;
+  project: Project;
+  suites: { suite: Suite; ignored: boolean }[];
+}> = ({ ignoreSuite, project, suites }) => {
+  const [expanded, setExpanded] = useState(false);
+  const toggleExpanded = () => setExpanded(prev => !prev);
+
+  return (
+    <>
+      <div className='ignore-section' onClick={toggleExpanded}>
+        <div className='search-header'>{project.name}</div>
+        <aha-icon
+          className='chevron'
+          icon={
+            expanded ? 'fa-solid fa-chevron-down' : 'fa-solid fa-chevron-right'
+          }
+        />
+      </div>
+      {expanded && (
+        <>
+          {suites.map(({ suite, ignored }) => (
+            <IgnoreSuiteRow
+              key={suite.id}
+              setIgnoredSuites={ignoreSuite}
+              suite={suite}
+              ignored={ignored}
+            />
+          ))}
+        </>
+      )}
+    </>
+  );
+};
+
+const SuiteRow: React.FC<RowProps> = ({ domain, disabled }) => {
+  const [loading, setLoading] = useState(true);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [suiteMapping, setSuiteMapping] = useState<{ [key: number]: Suite[] }>(
+    {}
+  );
+
+  const [projectMapping, setProjectMapping] = useState<{
+    [key: number]: Project;
+  }>({});
+
+  const [ignoredSuiteIds, setIgnoredSuiteIds] = useState<number[]>([]);
+  const [showIgnoreSection, setShowIgnoreSection] = useState(false);
+  const [reload, setReload] = useState(0);
+
+  const reloadSuites = () => {
+    setReload(prev => prev + 1);
+  };
+
+  const ignoreSuite = (id: number, isIgnored: boolean) => {
+    setIgnoredSuiteIds(prev =>
+      isIgnored ? [...prev, id] : prev.filter(suiteId => suiteId !== id)
+    );
+  };
+
+  const updateIgnoredSuites = async () => {
+    await deleteIgnoredSuiteRecords(ignoredSuiteIds);
+    await aha.account.setExtensionField(
+      IDENTIFIER,
+      'ignoredSuites',
+      ignoredSuiteIds
+    );
+    await showSuccess('Ignored suites successfully updated');
+    reloadSuites();
+  };
+
+  useEffect(() => {
+    const fetchSuites = async () => {
+      setLoading(() => true);
+
+      const projectIds =
+        (await aha.account.getExtensionField<number[]>(
+          IDENTIFIER,
+          'projectIds'
+        )) || [];
+
+      const ignored =
+        (await aha.account.getExtensionField<number[]>(
+          IDENTIFIER,
+          'ignoredSuites'
+        )) || [];
+      setIgnoredSuiteIds(ignored);
+
+      const keys = projectIds.map(projectId =>
+        indexKeyForKindAndParent('Suite', projectId)
+      );
+
+      const suiteIds = (await getAccountExtensionFields<number[]>(keys)).flat();
+      const allSuites = await getRecords<Suite>(
+        suiteIds.concat(ignored),
+        'Suite'
+      );
+
+      const mapping = {};
+      allSuites.forEach(suite => {
+        if (!mapping[suite.projectId]) {
+          mapping[suite.projectId] = [];
+        }
+        mapping[suite.projectId].push(suite);
+      });
+
+      setSuiteMapping(mapping);
+
+      const projects =
+        (await getAccountExtensionFieldMap<Project>(
+          Object.keys(mapping).map(id =>
+            fieldName('Project', Number.parseInt(id))
+          )
+        )) || {};
+
+      setProjectMapping(projects);
+      setLoading(() => false);
+    };
+
+    fetchSuites();
+  }, [reload]);
+
+  const projectSuiteMapping = useMemo(() => {
+    const mapping: { [key: number]: { suite: Suite; ignored: boolean }[] } = {};
+
+    Object.entries(suiteMapping).forEach(([projectId, suites]) => {
+      mapping[projectId] = suites.map(suite => ({
+        suite,
+        ignored: ignoredSuiteIds.some(id => id === suite.id),
+      }));
+    });
+
+    return mapping;
+  }, [ignoredSuiteIds, suiteMapping]);
+
+  return (
+    <>
+      <BaseSyncRow
+        recordType='Test suites'
+        resync={async (props: ResyncProps) => {
+          await resync(props);
+          reloadSuites();
+        }}
+        domain={domain}
+        disabled={disabled}
+        syncKey='syncingSuites'
+        lastSyncKey='lastSuiteSync'
+      />
+
+      <>
+        <div
+          className='ignore-section'
+          onClick={() => setShowIgnoreSection(ignoreSection => !ignoreSection)}
+        >
+          <div className='search-header'>Ignored suites</div>
+          <aha-icon
+            className='chevron'
+            icon={
+              showIgnoreSection
+                ? 'fa-solid fa-chevron-down'
+                : 'fa-solid fa-chevron-right'
+            }
+          />
+        </div>
+        {showIgnoreSection && (
+          <>
+            {loading ? (
+              <aha-loading-row class='search-loader' rows={5} columns={2} />
+            ) : (
+              Object.entries(projectSuiteMapping).map(([projectId, suites]) => {
+                const intProjectId = parseInt(projectId);
+
+                return (
+                  <IgnoreSuiteProjectRow
+                    key={intProjectId}
+                    ignoreSuite={ignoreSuite}
+                    project={projectMapping[fieldName('Project', intProjectId)]}
+                    suites={suites}
+                  />
+                );
+              })
+            )}
+          </>
+        )}
+        {showIgnoreSection && !loading && (
+          <>
+            <div className='ignore-button'>
+              <aha-button kind='primary' onClick={() => setModalOpen(true)}>
+                Update ignored suites
+              </aha-button>
+            </div>
+            {modalOpen && (
+              <ConfirmIgnoreModal
+                onClose={() => setModalOpen(false)}
+                onConfirm={updateIgnoredSuites}
+              />
+            )}
+          </>
+        )}
+      </>
+    </>
   );
 };
 

--- a/src/components/syncRows/TestCaseRow.tsx
+++ b/src/components/syncRows/TestCaseRow.tsx
@@ -20,13 +20,23 @@ const resync: (props: ResyncProps) => Promise<void> = async ({
         'projectIds'
       )) ?? [];
 
-    const projectSuites = await getProjectSuiteMapping(projectIds);
+    const ignoredSuites =
+      (await aha.account.getExtensionField<number[]>(
+        IDENTIFIER,
+        'ignoredSuites'
+      )) ?? [];
+
+    const projectSuites = await getProjectSuiteMapping(
+      projectIds,
+      ignoredSuites
+    );
     const now = Date.now();
 
     await syncCases({
       domain,
       projectSuites,
       lastCaseSync: lastSync,
+      ignoredSuiteIds: ignoredSuites,
     });
     await setLastSync(now);
   } catch (error) {

--- a/src/components/tabs/FeatureTab.tsx
+++ b/src/components/tabs/FeatureTab.tsx
@@ -48,7 +48,7 @@ const getFeatureTabData: (
     {}
   );
 
-  const [runTestMap, runTests] = await getRunRowData(runIds);
+  const [runTestMap, runTests] = await getRunRowData(runs.map(run => run.id));
 
   const testIdSet = new Set(runTests.map(test => test.id));
   const statusIds = new Set(runTests.map(test => test.statusId));
@@ -132,7 +132,11 @@ const FeatureTab: React.FC<TabProps> = ({ record, fields, settings }) => {
       statuses: {},
     };
 
-  if (caseIds) {
+  // Prevent errors if a linked record was deleted (e.g. from the suite ignore-list)
+  const existingCaseIds = testCases.map(testCase => testCase.id);
+  const existingRunIds = runs.map(run => run.id);
+
+  if (testCases.length > 0) {
     caseRows = testCases.map(testCase => {
       const test = tests[testCase.id];
       const status = test && statuses[test.statusId];
@@ -153,7 +157,7 @@ const FeatureTab: React.FC<TabProps> = ({ record, fields, settings }) => {
     });
   }
 
-  if (runIds) {
+  if (runs.length > 0) {
     runRows = runs.map(run => {
       const rows = runTestMap[run.id] ?? [];
 
@@ -222,7 +226,7 @@ const FeatureTab: React.FC<TabProps> = ({ record, fields, settings }) => {
         {linkRunModalOpen && (
           <LinkTestRun
             record={record}
-            runIds={runIds}
+            runIds={existingRunIds}
             syncData={syncData}
             onClose={() => setLinkRunModalOpen(false)}
           />
@@ -230,7 +234,7 @@ const FeatureTab: React.FC<TabProps> = ({ record, fields, settings }) => {
         {linkCaseModalOpen && (
           <LinkTestCase
             record={record}
-            caseIds={caseIds}
+            caseIds={existingCaseIds}
             syncData={syncData}
             onClose={onClose(setLinkCaseModalOpen)}
           />
@@ -238,7 +242,7 @@ const FeatureTab: React.FC<TabProps> = ({ record, fields, settings }) => {
         {linkTestModalOpen && (
           <LinkTest
             record={record}
-            caseIds={caseIds}
+            caseIds={existingCaseIds}
             syncData={syncData}
             onClose={onClose(setLinkTestModalOpen)}
           />

--- a/src/components/tabs/SprintTab.tsx
+++ b/src/components/tabs/SprintTab.tsx
@@ -32,7 +32,7 @@ const getSprintTabData: (
   runIds: number[]
 ) => Promise<SprintTabData> = async runIds => {
   const runs = await getRecords<TestRun>(runIds, 'TestRun');
-  const [testMap, tests] = await getRunRowData(runIds);
+  const [testMap, tests] = await getRunRowData(runs.map(run => run.id));
 
   const commentMap = await getLinkedComments(tests.map(test => test.id));
 
@@ -96,7 +96,9 @@ const SprintTab: React.FC<TabProps> = ({ record, fields, settings }) => {
     statuses: {},
   };
 
-  if (runIds) {
+  const existingRunIds = runs.map(run => run.id);
+
+  if (runs.length > 0) {
     runRows = runs.map(run => {
       const rows = testMap[run.id] ?? [];
 
@@ -139,7 +141,7 @@ const SprintTab: React.FC<TabProps> = ({ record, fields, settings }) => {
         {linkRunModalOpen && (
           <LinkTestRun
             record={record}
-            runIds={runIds}
+            runIds={existingRunIds}
             syncData={syncData}
             onClose={() => setLinkRunModalOpen(false)}
           />

--- a/src/lib/extensionFields/queries.test.ts
+++ b/src/lib/extensionFields/queries.test.ts
@@ -262,7 +262,7 @@ describe('getProjectSuiteMapping', () => {
   });
 
   it('returns empty object for empty input', async () => {
-    const result = await getProjectSuiteMapping([]);
+    const result = await getProjectSuiteMapping([], []);
     expect(result).toEqual({});
   });
 
@@ -272,11 +272,27 @@ describe('getProjectSuiteMapping', () => {
       { name: 'project_2_suiteIds', value: [3, 4] },
     ]);
 
-    const result = await getProjectSuiteMapping([1, 2]);
+    const result = await getProjectSuiteMapping([1, 2], []);
 
     expect(result).toEqual({
       1: [1, 2],
       2: [3, 4],
+    });
+  });
+
+  it('ignores specified suite IDs', async () => {
+    const ignoredSuiteIds = [2, 4];
+
+    mockQueryFields.mockResolvedValue([
+      { name: 'project_1_suiteIds', value: [1, 2] },
+      { name: 'project_2_suiteIds', value: [3, 4] },
+    ]);
+
+    const result = await getProjectSuiteMapping([1, 2], ignoredSuiteIds);
+
+    expect(result).toEqual({
+      1: [1],
+      2: [3],
     });
   });
 });

--- a/src/lib/extensionFields/queries.ts
+++ b/src/lib/extensionFields/queries.ts
@@ -89,7 +89,7 @@ export const getAccountExtensionFieldMap: <T>(
   }, {});
 };
 
-const getAccountExtensionFields: <T>(
+export const getAccountExtensionFields: <T>(
   names: string[]
 ) => Promise<T[]> = async names => {
   const extensionFields = await queryExtensionFields(names);
@@ -135,7 +135,21 @@ export const getProjectRecords: <
 
   const records = await getRecords<T>(ids, kind);
 
+  let ignoredSuites = [];
+
+  if (kind === 'Suite') {
+    ignoredSuites =
+      (await aha.account.getExtensionField<number[]>(
+        IDENTIFIER,
+        'ignoredSuites'
+      )) || [];
+  }
+
   for (const record of records) {
+    if (kind === 'Suite' && ignoredSuites.includes(record.id)) {
+      continue;
+    }
+
     if (!mapping[record.projectId]) {
       mapping[record.projectId] = [];
     }
@@ -147,8 +161,12 @@ export const getProjectRecords: <
 };
 
 export const getProjectSuiteMapping: (
-  projectIds: number[] | undefined
-) => Promise<{ [projectId: number]: number[] }> = async projectIds => {
+  projectIds: number[] | undefined,
+  ignoredSuites: number[]
+) => Promise<{ [projectId: number]: number[] }> = async (
+  projectIds,
+  ignoredSuites
+) => {
   if (!projectIds || projectIds.length === 0) return {};
 
   const keys = projectIds.map(projectId =>
@@ -161,11 +179,17 @@ export const getProjectSuiteMapping: (
   for (const key in suiteFields) {
     const projectId = key.split('_')[1];
 
+    const visibleSuites = suiteFields[key].filter(
+      suiteId => !ignoredSuites.includes(suiteId)
+    );
+
+    if (visibleSuites.length === 0) continue;
+
     if (!projectSuites[projectId]) {
       projectSuites[projectId] = [];
     }
 
-    projectSuites[projectId].push(...suiteFields[key]);
+    projectSuites[projectId].push(...visibleSuites);
   }
 
   return projectSuites;

--- a/src/lib/extensionFields/queryExtensionFields.ts
+++ b/src/lib/extensionFields/queryExtensionFields.ts
@@ -9,6 +9,7 @@ const queryExtensionFields: (
 ) => Promise<Aha.ExtensionField[]> = async (names: string[]) => {
   if (!names || names.length === 0) return [];
 
+  // @ts-ignore
   const results = await aha.models.ExtensionField.select('name', 'value')
     .where({
       names: names,

--- a/src/lib/extensionFields/updates.ts
+++ b/src/lib/extensionFields/updates.ts
@@ -171,3 +171,12 @@ const saveChunked: (
     await aha.account.setExtensionFields(IDENTIFIER, chunkFields);
   }
 };
+
+export const deleteChunked: (
+  fields: string[]
+) => Promise<void> = async fields => {
+  for (let i = 0; i < fields.length; i += MAX_FIELDS_PER_SAVE) {
+    const chunk = fields.slice(i, i + MAX_FIELDS_PER_SAVE);
+    await aha.account.clearExtensionFields(IDENTIFIER, chunk);
+  }
+};

--- a/src/lib/ignore.test.ts
+++ b/src/lib/ignore.test.ts
@@ -1,0 +1,343 @@
+import { IDENTIFIER, Suite } from '../extension';
+import { deleteIgnoredSuiteRecords } from './ignore';
+import {
+  getAccountExtensionFields,
+  getProjectRecords,
+  getRecords,
+} from './extensionFields/queries';
+import { deleteChunked } from './extensionFields/updates';
+
+// Mock the global aha object
+const mockSetExtensionFields = jest.fn();
+(global as any).aha = {
+  account: {
+    setExtensionFields: mockSetExtensionFields,
+  },
+};
+
+// Mock the queries module
+jest.mock('./extensionFields/queries', () => {
+  const original = jest.requireActual('./extensionFields/queries');
+  return {
+    ...original,
+    getRecords: jest.fn(),
+    getProjectRecords: jest.fn(),
+    getAccountExtensionFields: jest.fn(),
+  };
+});
+
+// Mock the updates module
+jest.mock('./extensionFields/updates', () => ({
+  deleteChunked: jest.fn(),
+}));
+
+const mockGetRecords = getRecords as jest.Mock;
+const mockGetProjectRecords = getProjectRecords as jest.Mock;
+
+const mockGetAccountExtensionFields = getAccountExtensionFields as jest.Mock;
+
+const mockDeleteChunked = deleteChunked as jest.Mock;
+
+describe('deleteIgnoredSuiteRecords', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return early if suiteIds is empty', async () => {
+    await deleteIgnoredSuiteRecords([]);
+
+    expect(mockGetRecords).not.toHaveBeenCalled();
+    expect(mockGetProjectRecords).not.toHaveBeenCalled();
+    expect(mockDeleteChunked).not.toHaveBeenCalled();
+    expect(mockSetExtensionFields).not.toHaveBeenCalled();
+  });
+
+  it('should return early if suiteIds is null/undefined', async () => {
+    await deleteIgnoredSuiteRecords(undefined);
+
+    expect(mockGetRecords).not.toHaveBeenCalled();
+    expect(mockGetProjectRecords).not.toHaveBeenCalled();
+    expect(mockDeleteChunked).not.toHaveBeenCalled();
+    expect(mockSetExtensionFields).not.toHaveBeenCalled();
+  });
+
+  it('should delete records for ignored suites and update indexes', async () => {
+    const suiteIds = [1, 2];
+
+    const mockSuites: Suite[] = [
+      { id: 1, kind: 'Suite', name: 'Suite 1', projectId: 10 },
+      { id: 2, kind: 'Suite', name: 'Suite 2', projectId: 20 },
+    ];
+
+    const mockSections = {
+      10: [
+        {
+          id: 101,
+          kind: 'Section',
+          name: 'Section 1',
+          projectId: 10,
+          suiteId: 1,
+        },
+        {
+          id: 102,
+          kind: 'Section',
+          name: 'Section to keep',
+          projectId: 10,
+          suiteId: 3,
+        },
+      ],
+      20: [
+        {
+          id: 201,
+          kind: 'Section',
+          name: 'Section 3',
+          projectId: 20,
+          suiteId: 2,
+        },
+      ],
+    };
+
+    const mockTestCases = {
+      10: [
+        {
+          id: 301,
+          kind: 'TestCase',
+          title: 'Case 1',
+          projectId: 10,
+          suiteId: 1,
+          createdOn: 123,
+        },
+        {
+          id: 302,
+          kind: 'TestCase',
+          title: 'Case to keep',
+          projectId: 10,
+          suiteId: 3,
+          createdOn: 123,
+        },
+      ],
+      20: [
+        {
+          id: 401,
+          kind: 'TestCase',
+          title: 'Case 3',
+          projectId: 20,
+          suiteId: 2,
+          createdOn: 123,
+        },
+      ],
+    };
+
+    const mockTestRuns = {
+      10: [
+        {
+          id: 501,
+          kind: 'TestRun',
+          name: 'Run 1',
+          projectId: 10,
+          suiteId: 1,
+          createdOn: 123,
+          completed: false,
+        },
+        {
+          id: 502,
+          kind: 'TestRun',
+          name: 'Run to keep',
+          projectId: 10,
+          suiteId: 3,
+          createdOn: 123,
+          completed: false,
+        },
+      ],
+      20: [
+        {
+          id: 601,
+          kind: 'TestRun',
+          name: 'Run 3',
+          projectId: 20,
+          suiteId: 2,
+          createdOn: 123,
+          completed: false,
+        },
+      ],
+    };
+
+    mockGetRecords.mockResolvedValue(mockSuites);
+
+    mockGetProjectRecords
+      .mockResolvedValueOnce(mockSections)
+      .mockResolvedValueOnce(mockTestCases)
+      .mockResolvedValueOnce(mockTestRuns);
+
+    // No tests for the deleted runs in this example
+    mockGetAccountExtensionFields.mockResolvedValue([]);
+
+    await deleteIgnoredSuiteRecords(suiteIds);
+
+    // Verify we retrieved the correct records
+    expect(mockGetRecords).toHaveBeenCalledWith(suiteIds, 'Suite');
+
+    expect(mockGetProjectRecords).toHaveBeenCalledWith([10, 20], 'Section');
+    expect(mockGetProjectRecords).toHaveBeenCalledWith([10, 20], 'TestCase');
+    expect(mockGetProjectRecords).toHaveBeenCalledWith([10, 20], 'TestRun');
+
+    const expectedRecordsToDelete = [
+      'section_101',
+      'section_201',
+      'case_301',
+      'case_401',
+      'run_501',
+      'run_601',
+      'run_501_testIds',
+      'run_601_testIds',
+    ];
+
+    expect(mockDeleteChunked).toHaveBeenCalledWith(
+      expect.arrayContaining(expectedRecordsToDelete)
+    );
+
+    const expectedIndexUpdates = {
+      project_10_sectionIds: [102],
+      project_10_caseIds: [302],
+      project_10_runIds: [502],
+      project_20_sectionIds: [],
+      project_20_caseIds: [],
+      project_20_runIds: [],
+    };
+
+    expect(mockSetExtensionFields).toHaveBeenCalledWith(
+      IDENTIFIER,
+      expectedIndexUpdates
+    );
+  });
+
+  it('does nothing if there are no suites to delete', async () => {
+    const suiteIds = [1];
+
+    mockGetRecords.mockResolvedValue([]);
+    await deleteIgnoredSuiteRecords(suiteIds);
+
+    expect(mockGetProjectRecords).not.toHaveBeenCalled();
+
+    expect(mockDeleteChunked).not.toHaveBeenCalled();
+    expect(mockSetExtensionFields).not.toHaveBeenCalled();
+  });
+
+  it('should handle projects with no records gracefully', async () => {
+    const suiteIds = [1];
+
+    const mockSuites: Suite[] = [
+      { id: 1, kind: 'Suite', name: 'Suite 1', projectId: 10 },
+    ];
+
+    mockGetRecords.mockResolvedValue(mockSuites);
+    mockGetProjectRecords
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+
+    await deleteIgnoredSuiteRecords(suiteIds);
+
+    expect(mockGetRecords).toHaveBeenCalledWith(suiteIds, 'Suite');
+    expect(mockGetProjectRecords).toHaveBeenCalledTimes(3);
+
+    expect(mockDeleteChunked).not.toHaveBeenCalled();
+    expect(mockSetExtensionFields).not.toHaveBeenCalled();
+  });
+
+  it('should only update indexes that had records initially', async () => {
+    const suiteIds = [1];
+
+    const mockSuites: Suite[] = [
+      { id: 1, kind: 'Suite', name: 'Suite 1', projectId: 10 },
+    ];
+
+    const mockSections = {
+      10: [
+        {
+          id: 101,
+          kind: 'Section',
+          name: 'Section 1',
+          projectId: 10,
+          suiteId: 1,
+        },
+      ],
+    };
+
+    mockGetRecords.mockResolvedValue(mockSuites);
+    mockGetProjectRecords
+      .mockResolvedValueOnce(mockSections)
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+
+    await deleteIgnoredSuiteRecords(suiteIds);
+
+    const expectedIndexUpdates = {
+      project_10_sectionIds: [],
+    };
+
+    expect(mockSetExtensionFields).toHaveBeenCalledWith(
+      IDENTIFIER,
+      expectedIndexUpdates
+    );
+  });
+
+  it('deletes associated tests and results for deleted test runs', async () => {
+    const suiteIds = [1];
+
+    const mockSuites: Suite[] = [
+      { id: 1, kind: 'Suite', name: 'Suite 1', projectId: 10 },
+    ];
+
+    const mockTestRuns = {
+      10: [
+        {
+          id: 501,
+          kind: 'TestRun',
+          name: 'Run 1',
+          projectId: 10,
+          suiteId: 1,
+          createdOn: 123,
+          completed: false,
+        },
+        {
+          id: 502,
+          kind: 'TestRun',
+          name: 'Run to keep',
+          projectId: 10,
+          suiteId: 2,
+          createdOn: 123,
+          completed: false,
+        },
+      ],
+    };
+
+    mockGetRecords.mockResolvedValue(mockSuites);
+    mockGetProjectRecords
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce(mockTestRuns);
+
+    // Returned test IDs for the deleted run
+    mockGetAccountExtensionFields.mockResolvedValue([701, 702]);
+
+    await deleteIgnoredSuiteRecords(suiteIds);
+
+    expect(mockGetAccountExtensionFields).toHaveBeenCalledWith([
+      'run_501_testIds',
+    ]);
+
+    const expectedRecordsToDelete = [
+      'run_501',
+      'test_701',
+      'test_702',
+      'test_701_comment',
+      'test_702_comment',
+      'run_501_testIds',
+    ];
+
+    expect(mockDeleteChunked).toHaveBeenCalledWith(
+      expect.arrayContaining(expectedRecordsToDelete)
+    );
+  });
+});

--- a/src/lib/ignore.ts
+++ b/src/lib/ignore.ts
@@ -1,0 +1,104 @@
+import { IDENTIFIER, Section, Suite, TestCase, TestRun } from '../extension';
+import {
+  fieldName,
+  getAccountExtensionFields,
+  getProjectRecords,
+  getRecords,
+  indexKeyForKindAndParent,
+} from './extensionFields/queries';
+import { deleteChunked } from './extensionFields/updates';
+
+// Given a list of of ignored suite IDs, find all associated records (Sections, TestCases and TestRuns) and delete their references,
+// and mark the suites as ignored. Unfortunately we store records indexed by Project ID, so we have to fetch all records
+// for a project and then filter out those with the ignored suite IDs.
+//
+// We also have no way to delete the links on individual records - those should silently be ignored if they can't be found.
+export const deleteIgnoredSuiteRecords: (
+  suiteIds: number[]
+) => Promise<void> = async suiteIds => {
+  if (!suiteIds || suiteIds.length === 0) {
+    return;
+  }
+
+  const suites = await getRecords<Suite>(suiteIds, 'Suite');
+
+  if (!suites || suites.length === 0) {
+    return;
+  }
+
+  const projectIds = [...new Set(suites.map(suite => suite.projectId))];
+
+  const sections = await getProjectRecords<Section>(projectIds, 'Section');
+  const testCases = await getProjectRecords<TestCase>(projectIds, 'TestCase');
+  const testRuns = await getProjectRecords<TestRun>(projectIds, 'TestRun');
+
+  const recordsToDelete = [];
+  const indexesToUpdate = {};
+
+  for (const projectId of projectIds) {
+    const projectSections = sections[projectId] || [];
+    const projectTestCases = testCases[projectId] || [];
+    const projectTestRuns = testRuns[projectId] || [];
+
+    const sectionsToKeep = [];
+    const testCasesToKeep = [];
+    const testRunsToKeep = [];
+    const deletedRuns = [];
+
+    for (const section of projectSections) {
+      if (suiteIds.includes(section.suiteId)) {
+        recordsToDelete.push(fieldName('Section', section.id));
+      } else {
+        sectionsToKeep.push(section.id);
+      }
+    }
+
+    for (const testCase of projectTestCases) {
+      if (suiteIds.includes(testCase.suiteId)) {
+        recordsToDelete.push(fieldName('TestCase', testCase.id));
+      } else {
+        testCasesToKeep.push(testCase.id);
+      }
+    }
+
+    for (const testRun of projectTestRuns) {
+      if (suiteIds.includes(testRun.suiteId)) {
+        deletedRuns.push(testRun.id);
+        recordsToDelete.push(fieldName('TestRun', testRun.id));
+      } else {
+        testRunsToKeep.push(testRun.id);
+      }
+    }
+
+    // Only update if there were records in the index to start with
+    if (projectSections.length > 0)
+      indexesToUpdate[`project_${projectId}_sectionIds`] = sectionsToKeep;
+    if (projectTestCases.length > 0)
+      indexesToUpdate[`project_${projectId}_caseIds`] = testCasesToKeep;
+    if (projectTestRuns.length > 0)
+      indexesToUpdate[`project_${projectId}_runIds`] = testRunsToKeep;
+
+    // Delete any tests and results associated with deleted runs
+    if (deletedRuns.length > 0) {
+      const testIndexes = deletedRuns.map(runId => `run_${runId}_testIds`);
+      const testIds = (
+        await getAccountExtensionFields<number[]>(testIndexes)
+      ).flat();
+
+      for (const testId of testIds) {
+        recordsToDelete.push(fieldName('Test', testId));
+        recordsToDelete.push(indexKeyForKindAndParent('TestResult', testId));
+      }
+
+      recordsToDelete.push(...testIndexes);
+    }
+  }
+
+  if (recordsToDelete.length > 0) {
+    await deleteChunked(recordsToDelete);
+  }
+
+  if (Object.keys(indexesToUpdate).length > 0) {
+    await aha.account.setExtensionFields(IDENTIFIER, indexesToUpdate);
+  }
+};

--- a/src/lib/sync/bulkSync.ts
+++ b/src/lib/sync/bulkSync.ts
@@ -61,6 +61,7 @@ type SyncResults = {
   projectIds?: number[];
   projectSuites?: { [projectId: string]: number[] };
   runIds?: number[];
+  ignoredSuiteIds?: number[];
 };
 
 type BaseSyncStageProps = {
@@ -225,8 +226,23 @@ const bulkSync: (props: SyncProps) => Promise<void> = async ({
       IDENTIFIER,
       'projectIds'
     );
-    const projectSuites = await getProjectSuiteMapping(projectIds);
-    syncResults = { projectIds, projectSuites };
+
+    const ignoredSuites =
+      (await aha.account.getExtensionField<number[]>(
+        IDENTIFIER,
+        'ignoredSuites'
+      )) ?? [];
+
+    const projectSuites = await getProjectSuiteMapping(
+      projectIds,
+      ignoredSuites
+    );
+
+    syncResults = {
+      projectIds,
+      projectSuites,
+      ignoredSuiteIds: ignoredSuites,
+    };
   } else {
     syncState = { ...syncState, stage: getInitialStage(type), progress: 0 };
   }
@@ -315,6 +331,14 @@ const syncInitialRecords: (
 
     const projects = await syncProjects({ domain });
 
+    const ignoredSuites =
+      (await aha.account.getExtensionField<number[]>(
+        IDENTIFIER,
+        'ignoredSuites'
+      )) ?? [];
+
+    const ignoredSuiteIds = ignoredSuites;
+
     let nextStage = SyncStage.Suites;
     if (type === SyncType.Tests) {
       nextStage = SyncStage.OpenRuns;
@@ -339,6 +363,7 @@ const syncInitialRecords: (
     const suiteParams = {
       domain,
       projectIds,
+      ignoredSuiteIds,
     };
 
     const projectSuites = {};
@@ -363,6 +388,7 @@ const syncInitialRecords: (
     const sectionParams = {
       domain,
       projectSuites,
+      ignoredSuiteIds,
     };
 
     await syncSections(sectionParams);
@@ -375,8 +401,9 @@ const syncInitialRecords: (
 
     await setSyncState(newSyncState);
 
-    return [{ projectIds, projectSuites }, newSyncState];
+    return [{ projectIds, projectSuites, ignoredSuiteIds }, newSyncState];
   } catch (error) {
+    console.log('Error during sync:', error);
     syncState = { ...newSyncState, state: SyncState.Errored };
     await setSyncState(syncState);
 
@@ -404,6 +431,7 @@ const syncRequiresProjects: (
         domain,
         projectSuites: results.projectSuites,
         lastCaseSync: lastSync,
+        ignoredSuiteIds: results.ignoredSuiteIds,
       };
 
       await syncCases(caseParams);
@@ -425,6 +453,7 @@ const syncRequiresProjects: (
     const baseParams = {
       domain,
       projectIds: results.projectIds,
+      ignoredSuiteIds: results.ignoredSuiteIds,
     };
 
     const runParams = { ...baseParams, lastRunSync: lastSync };
@@ -473,6 +502,7 @@ const syncRequiresProjects: (
 
     return [{ ...results, runIds: runs.map(run => run.id) }, newSyncState];
   } catch (error) {
+    console.log('Error during sync:', error);
     syncState = { ...newSyncState, state: SyncState.Errored };
     await setSyncState(syncState);
 
@@ -518,6 +548,7 @@ const syncRequiresRuns: (
 
     await finishSync(newSyncState, type, setSyncState);
   } catch (error) {
+    console.log('Error during sync:', error);
     syncState = { ...newSyncState, state: SyncState.Errored };
     await setSyncState(syncState);
 

--- a/src/lib/sync/syncCases.test.ts
+++ b/src/lib/sync/syncCases.test.ts
@@ -26,14 +26,16 @@ describe('syncCases', () => {
     jest.clearAllMocks();
   });
 
-  it('throws error if no projects found', async () => {
-    await expect(
-      syncCases({
-        domain: 'test',
-        lastCaseSync: 0,
-        projectSuites: {},
-      })
-    ).rejects.toThrow('No synced projects found, aborting test case sync.');
+  it('early returns if no projects found', async () => {
+    const result = await syncCases({
+      domain: 'test',
+      lastCaseSync: 0,
+      projectSuites: {},
+      ignoredSuiteIds: [],
+    });
+    expect(result).toEqual([]);
+
+    expect(mockSetExtensionField).not.toHaveBeenCalled();
   });
 
   it('syncs cases', async () => {
@@ -65,6 +67,7 @@ describe('syncCases', () => {
         '1': [100, 101],
         '2': [102],
       },
+      ignoredSuiteIds: [],
     });
 
     expect(waitForIndexedLambda).toHaveBeenCalledWith({
@@ -92,6 +95,43 @@ describe('syncCases', () => {
     expect(result).toEqual(mockCases);
   });
 
+  it('does not save cases from ignored suites', async () => {
+    const mockCases: TestCase[] = [
+      {
+        id: 1,
+        kind: 'TestCase',
+        projectId: 1,
+        suiteId: 2,
+        title: 'Case 1',
+        createdOn: 0,
+      },
+    ];
+
+    mockWaitIndexed.mockResolvedValue(mockCases);
+    const ignoredSuiteIds = [1];
+
+    const result = await syncCases({
+      domain: 'test',
+      lastCaseSync: 0,
+      projectSuites: {
+        '1': [1, 2],
+      },
+      ignoredSuiteIds,
+    });
+
+    expect(waitForIndexedLambda).toHaveBeenCalledWith({
+      lambdaFunc: expect.any(Function),
+      args: { domain: 'test' },
+      eventKey: expect.stringContaining('syncCases-'),
+      argFunc: expect.any(Function),
+      numIds: 1,
+    });
+
+    const { argFunc } = mockWaitIndexed.mock.calls[0][0];
+
+    expect(argFunc(0)).toEqual({ projectId: '1', suiteId: 2 });
+  });
+
   it('includes updatedAfter parameter when lastCaseSync provided', async () => {
     const lastSync = Date.now();
     mockWaitIndexed.mockResolvedValue([]);
@@ -100,6 +140,7 @@ describe('syncCases', () => {
       domain: 'test',
       lastCaseSync: lastSync,
       projectSuites: { '1': [] },
+      ignoredSuiteIds: [],
     });
 
     expect(waitForIndexedLambda).toHaveBeenCalledWith({

--- a/src/lib/sync/syncCases.ts
+++ b/src/lib/sync/syncCases.ts
@@ -7,15 +7,17 @@ type SyncProps = BaseSyncProps & {
   projectSuites: {
     [projectId: string]: number[];
   };
+  ignoredSuiteIds: number[];
 };
 
 const syncCases: (props: SyncProps) => Promise<TestCase[]> = async ({
   domain,
   lastCaseSync,
   projectSuites,
+  ignoredSuiteIds,
 }) => {
   if (Object.keys(projectSuites).length === 0) {
-    throw new Error('No synced projects found, aborting test case sync.');
+    return []; // Possible if syncing out of order or all suites are ignored
   }
 
   const now = Date.now();
@@ -32,6 +34,8 @@ const syncCases: (props: SyncProps) => Promise<TestCase[]> = async ({
     }
 
     for (const suiteId of projectSuites[projectId]) {
+      if (ignoredSuiteIds.includes(suiteId)) continue;
+
       lambdaArgs.push({ projectId, suiteId });
     }
   }

--- a/src/lib/sync/syncPlans.test.ts
+++ b/src/lib/sync/syncPlans.test.ts
@@ -30,20 +30,26 @@ describe('syncOpenPlans', () => {
     jest.clearAllMocks();
   });
 
-  it('throws error if no project IDs provided', async () => {
-    await expect(
-      syncOpenPlans({ domain: 'test', projectIds: [] })
-    ).rejects.toThrow(
-      'No synced projects found, skipping open test plan sync.'
-    );
+  it('returns without saving last sync if no projects provided', async () => {
+    const result = await syncOpenPlans({
+      domain: 'test',
+      projectIds: [],
+      ignoredSuiteIds: [],
+    });
+    expect(result).toEqual([]);
+
+    expect(mockSetExtensionField).not.toHaveBeenCalled();
   });
 
-  it('throws error if project IDs undefined', async () => {
-    await expect(
-      syncOpenPlans({ domain: 'test', projectIds: undefined })
-    ).rejects.toThrow(
-      'No synced projects found, skipping open test plan sync.'
-    );
+  it('returns an empty array if projects is undefined', async () => {
+    const result = await syncOpenPlans({
+      domain: 'test',
+      projectIds: undefined,
+      ignoredSuiteIds: [],
+    });
+    expect(result).toEqual([]);
+
+    expect(mockSetExtensionField).not.toHaveBeenCalled();
   });
 
   it('syncs open plans and their runs', async () => {
@@ -73,7 +79,11 @@ describe('syncOpenPlans', () => {
     mockWaitIndexed.mockResolvedValue(mockPlanIds);
     mockWaitPaged.mockResolvedValue(mockRuns);
 
-    const result = await syncOpenPlans({ domain: 'test', projectIds: [1, 2] });
+    const result = await syncOpenPlans({
+      domain: 'test',
+      projectIds: [1, 2],
+      ignoredSuiteIds: [],
+    });
 
     expect(waitForIndexedLambda).toHaveBeenCalledWith({
       lambdaFunc: expect.any(Function),
@@ -106,6 +116,68 @@ describe('syncOpenPlans', () => {
     expect(saveRecords).toHaveBeenCalledWith(mockRuns);
     expect(result).toEqual(mockRuns);
   });
+
+  it('does not sync runs for ignored suites', async () => {
+    const mockPlanIds = [1, 2];
+
+    const mockRuns = [
+      {
+        id: 1,
+        kind: 'TestRun',
+        projectId: 100,
+        suiteId: 1,
+        name: 'Run 1',
+        createdOn: Date.now(),
+        completed: false,
+      },
+      {
+        id: 2,
+        kind: 'TestRun',
+        projectId: 100,
+        suiteId: 2,
+        name: 'Run 2',
+        createdOn: Date.now(),
+        completed: false,
+      },
+    ];
+
+    mockWaitIndexed.mockResolvedValue(mockPlanIds);
+    mockWaitPaged.mockResolvedValue(mockRuns);
+
+    const result = await syncOpenPlans({
+      domain: 'test',
+      projectIds: [1, 2],
+      ignoredSuiteIds: [1],
+    });
+
+    expect(waitForIndexedLambda).toHaveBeenCalledWith({
+      lambdaFunc: expect.any(Function),
+      args: { domain: 'test', isCompleted: 0 },
+      eventKey: expect.stringContaining('syncPlans-'),
+      argFunc: expect.any(Function),
+      numIds: 2,
+    });
+
+    expect(waitForPagedLambda).toHaveBeenCalledWith({
+      lambdaFunc: expect.any(Function),
+      args: { domain: 'test' },
+      eventKey: expect.stringContaining('syncPlanRuns-'),
+      usePage: false,
+      isPaginated: false,
+      idKey: 'planId',
+      ids: mockPlanIds,
+    });
+
+    expect(mockSetExtensionField).toHaveBeenCalledWith(
+      IDENTIFIER,
+      'lastPlanSync',
+      expect.any(Number)
+    );
+
+    const filteredRuns = mockRuns.filter(run => run.suiteId !== 1);
+    expect(saveRecords).toHaveBeenCalledWith(filteredRuns);
+    expect(result).toEqual(filteredRuns);
+  });
 });
 
 describe('syncCompletedPlans', () => {
@@ -113,20 +185,26 @@ describe('syncCompletedPlans', () => {
     jest.clearAllMocks();
   });
 
-  it('throws error if no project IDs provided', async () => {
-    await expect(
-      syncCompletedPlans({ domain: 'test', projectIds: [] })
-    ).rejects.toThrow(
-      'No synced projects found, skipping completed test plan sync.'
-    );
+  it('early returns if no project IDs provided', async () => {
+    const result = await syncCompletedPlans({
+      domain: 'test',
+      projectIds: [],
+      ignoredSuiteIds: [],
+    });
+    expect(result).toEqual([]);
+
+    expect(mockSetExtensionField).not.toHaveBeenCalled();
   });
 
-  it('throws error if project IDs undefined', async () => {
-    await expect(
-      syncCompletedPlans({ domain: 'test', projectIds: undefined })
-    ).rejects.toThrow(
-      'No synced projects found, skipping completed test plan sync.'
-    );
+  it('early returns if project IDs undefined', async () => {
+    const result = await syncCompletedPlans({
+      domain: 'test',
+      projectIds: undefined,
+      ignoredSuiteIds: [],
+    });
+    expect(result).toEqual([]);
+
+    expect(mockSetExtensionField).not.toHaveBeenCalled();
   });
 
   it('syncs completed plans and their runs', async () => {
@@ -161,6 +239,7 @@ describe('syncCompletedPlans', () => {
     const result = await syncCompletedPlans({
       domain: 'test',
       projectIds: [1, 2],
+      ignoredSuiteIds: [],
     });
 
     expect(waitForPagedLambda).toHaveBeenCalledWith(
@@ -194,5 +273,78 @@ describe('syncCompletedPlans', () => {
 
     expect(saveNewRuns).toHaveBeenCalledWith(mockRuns);
     expect(result).toEqual(mockRuns);
+  });
+
+  it('does not sync runs for ignored suites', async () => {
+    const mockPlanIds = [1, 2];
+    const ignoredSuiteIds = [1];
+
+    const mockRuns = [
+      {
+        id: 1,
+        kind: 'TestRun',
+        projectId: 100,
+        suiteId: 1,
+        name: 'Run 1',
+        createdOn: Date.now(),
+        completed: true,
+      },
+      {
+        id: 2,
+        kind: 'TestRun',
+        projectId: 100,
+        suiteId: 2,
+        name: 'Run 2',
+        createdOn: Date.now(),
+        completed: true,
+      },
+    ];
+
+    const filteredRuns = mockRuns.filter(
+      run => !ignoredSuiteIds.includes(run.suiteId)
+    );
+
+    mockWaitPaged
+      .mockResolvedValueOnce(mockPlanIds)
+      .mockResolvedValueOnce(mockRuns);
+    mockSaveRuns.mockResolvedValue(filteredRuns);
+
+    const result = await syncCompletedPlans({
+      domain: 'test',
+      projectIds: [1, 2],
+      ignoredSuiteIds,
+    });
+
+    expect(waitForPagedLambda).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lambdaFunc: expect.any(Function),
+        args: { domain: 'test', isCompleted: 1, limit: 250 },
+        eventKey: expect.stringContaining('syncCompletedPlans-'),
+        usePage: false,
+        idKey: 'projectId',
+        ids: [1, 2],
+      })
+    );
+
+    expect(waitForPagedLambda).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lambdaFunc: expect.any(Function),
+        args: { domain: 'test' },
+        eventKey: expect.stringContaining('syncPlanRuns-'),
+        usePage: false,
+        isPaginated: false,
+        idKey: 'planId',
+        ids: mockPlanIds,
+      })
+    );
+
+    expect(mockSetExtensionField).toHaveBeenCalledWith(
+      IDENTIFIER,
+      'lastCompletedPlanSync',
+      expect.any(Number)
+    );
+
+    expect(saveNewRuns).toHaveBeenCalledWith(filteredRuns);
+    expect(result).toEqual(filteredRuns);
   });
 });

--- a/src/lib/sync/syncPlans.ts
+++ b/src/lib/sync/syncPlans.ts
@@ -11,22 +11,25 @@ const NUM_COMPLETED_PLANS = 250;
 
 type SyncPlanProps = BaseSyncProps & {
   projectIds: number[];
+  ignoredSuiteIds: number[];
 };
 
 type SyncCompletedProps = BaseSyncProps & {
   projectIds: number[];
+  ignoredSuiteIds: number[];
 };
 
 type SyncRunProps = BaseSyncProps & {
   planIds: number[];
   completed?: boolean;
+  ignoredSuiteIds: number[];
 };
 
 export const syncOpenPlans: (
   props: SyncPlanProps
-) => Promise<TestRun[]> = async ({ domain, projectIds }) => {
+) => Promise<TestRun[]> = async ({ domain, projectIds, ignoredSuiteIds }) => {
   if (!projectIds?.length) {
-    throw new Error('No synced projects found, skipping open test plan sync.');
+    return [];
   }
 
   const now = Date.now();
@@ -50,18 +53,16 @@ export const syncOpenPlans: (
   });
 
   await aha.account.setExtensionField(IDENTIFIER, 'lastPlanSync', now);
-  return await syncRunsForPlan({ domain, planIds: openPlans });
+  return await syncRunsForPlan({ domain, ignoredSuiteIds, planIds: openPlans });
 };
 
 // This stage is primarily useful for first sync to get historical data,
 // or as a backup if a plan managed to open and close between syncs of open plans.
 export const syncCompletedPlans: (
   props: SyncCompletedProps
-) => Promise<TestRun[]> = async ({ domain, projectIds }) => {
+) => Promise<TestRun[]> = async ({ domain, projectIds, ignoredSuiteIds }) => {
   if (!projectIds?.length) {
-    throw new Error(
-      'No synced projects found, skipping completed test plan sync.'
-    );
+    return [];
   }
 
   const now = Date.now();
@@ -84,13 +85,19 @@ export const syncCompletedPlans: (
   });
 
   await aha.account.setExtensionField(IDENTIFIER, 'lastCompletedPlanSync', now);
-  return await syncRunsForPlan({ domain, planIds, completed: true });
+  return await syncRunsForPlan({
+    domain,
+    ignoredSuiteIds,
+    planIds,
+    completed: true,
+  });
 };
 
 const syncRunsForPlan: (props: SyncRunProps) => Promise<TestRun[]> = async ({
   domain,
   planIds,
   completed = false,
+  ignoredSuiteIds,
 }) => {
   if (!planIds || planIds.length === 0) {
     return [];
@@ -111,6 +118,8 @@ const syncRunsForPlan: (props: SyncRunProps) => Promise<TestRun[]> = async ({
     idKey: 'planId',
     ids: planIds,
   });
+
+  runs = runs.filter(run => !ignoredSuiteIds.includes(run.suiteId));
 
   // When syncing completed plans, only save new records to reduce syncing effort.
   if (completed) {

--- a/src/lib/sync/syncRuns.test.ts
+++ b/src/lib/sync/syncRuns.test.ts
@@ -30,16 +30,26 @@ describe('syncOpenRuns', () => {
     jest.clearAllMocks();
   });
 
-  it('throws error if no project IDs provided', async () => {
-    await expect(
-      syncOpenRuns({ domain: 'test', projectIds: [] })
-    ).rejects.toThrow('No synced projects found, aborting open test run sync.');
+  it('early returns if no project IDs provided', async () => {
+    const result = await syncOpenRuns({
+      domain: 'test',
+      projectIds: [],
+      ignoredSuiteIds: [],
+    });
+
+    expect(result).toEqual([]);
+    expect(mockSetExtensionField).not.toHaveBeenCalled();
   });
 
-  it('throws error if project IDs undefined', async () => {
-    await expect(
-      syncOpenRuns({ domain: 'test', projectIds: undefined })
-    ).rejects.toThrow('No synced projects found, aborting open test run sync.');
+  it('early returns if project IDs undefined', async () => {
+    const result = await syncOpenRuns({
+      domain: 'test',
+      projectIds: undefined,
+      ignoredSuiteIds: [],
+    });
+
+    expect(result).toEqual([]);
+    expect(mockSetExtensionField).not.toHaveBeenCalled();
   });
 
   it('syncs and saves open runs', async () => {
@@ -66,7 +76,11 @@ describe('syncOpenRuns', () => {
 
     mockWaitIndexed.mockResolvedValue(mockRuns);
 
-    const result = await syncOpenRuns({ domain: 'test', projectIds: [1, 2] });
+    const result = await syncOpenRuns({
+      domain: 'test',
+      projectIds: [1, 2],
+      ignoredSuiteIds: [],
+    });
 
     expect(waitForIndexedLambda).toHaveBeenCalledWith({
       lambdaFunc: expect.any(Function),
@@ -90,11 +104,68 @@ describe('syncOpenRuns', () => {
   it('passes correct project ID to argFunc', async () => {
     mockWaitIndexed.mockResolvedValue([]);
 
-    await syncOpenRuns({ domain: 'test', projectIds: [42] });
+    await syncOpenRuns({
+      domain: 'test',
+      projectIds: [42],
+      ignoredSuiteIds: [],
+    });
 
     const { argFunc } = mockWaitIndexed.mock.calls[0][0];
 
     expect(argFunc(0)).toEqual({ projectId: 42 });
+  });
+
+  it('does not sync runs with ignored suite IDs', async () => {
+    const mockRuns: TestRun[] = [
+      {
+        id: 1,
+        kind: 'TestRun',
+        projectId: 1,
+        suiteId: 1,
+        createdOn: 0,
+        name: 'Run 1',
+        completed: false,
+      },
+      {
+        id: 2,
+        kind: 'TestRun',
+        projectId: 1,
+        suiteId: 2,
+        createdOn: 0,
+        name: 'Run 2',
+        completed: false,
+      },
+    ];
+    const ignoredSuiteIds = [2];
+
+    mockWaitIndexed.mockResolvedValue(mockRuns);
+
+    const result = await syncOpenRuns({
+      domain: 'test',
+      projectIds: [1],
+      ignoredSuiteIds,
+    });
+
+    const filteredRuns = mockRuns.filter(
+      run => !ignoredSuiteIds.includes(run.suiteId)
+    );
+
+    expect(waitForIndexedLambda).toHaveBeenCalledWith({
+      lambdaFunc: expect.any(Function),
+      args: { domain: 'test', isCompleted: 0 },
+      eventKey: expect.stringContaining('syncRuns-'),
+      argFunc: expect.any(Function),
+      numIds: 1,
+    });
+
+    expect(saveRecords).toHaveBeenCalledWith(filteredRuns);
+    expect(mockSetExtensionField).toHaveBeenCalledWith(
+      IDENTIFIER,
+      'lastRunSync',
+      expect.any(Number)
+    );
+
+    expect(result).toEqual(filteredRuns);
   });
 });
 
@@ -103,20 +174,26 @@ describe('syncCompletedRuns', () => {
     jest.clearAllMocks();
   });
 
-  it('throws error if no project IDs provided', async () => {
-    await expect(
-      syncCompletedRuns({ domain: 'test', projectIds: [] })
-    ).rejects.toThrow(
-      'No synced projects found, aborting completed test run sync.'
-    );
+  it('early returns if no project IDs provided', async () => {
+    const result = await syncCompletedRuns({
+      domain: 'test',
+      projectIds: [],
+      ignoredSuiteIds: [],
+    });
+
+    expect(result).toEqual([]);
+    expect(mockSetExtensionField).not.toHaveBeenCalled();
   });
 
-  it('throws error if project IDs undefined', async () => {
-    await expect(
-      syncCompletedRuns({ domain: 'test', projectIds: undefined })
-    ).rejects.toThrow(
-      'No synced projects found, aborting completed test run sync.'
-    );
+  it('early returns if project IDs undefined', async () => {
+    const result = await syncCompletedRuns({
+      domain: 'test',
+      projectIds: undefined,
+      ignoredSuiteIds: [],
+    });
+
+    expect(result).toEqual([]);
+    expect(mockSetExtensionField).not.toHaveBeenCalled();
   });
 
   it('syncs and saves completed runs', async () => {
@@ -147,6 +224,7 @@ describe('syncCompletedRuns', () => {
     const result = await syncCompletedRuns({
       domain: 'test',
       projectIds: [1, 2],
+      ignoredSuiteIds: [],
     });
 
     expect(waitForPagedLambda).toHaveBeenCalledWith({
@@ -167,5 +245,60 @@ describe('syncCompletedRuns', () => {
     );
 
     expect(result).toEqual(mockRuns);
+  });
+
+  it('does not sync runs with ignored suite IDs', async () => {
+    const mockRuns: TestRun[] = [
+      {
+        id: 1,
+        kind: 'TestRun',
+        projectId: 1,
+        suiteId: 1,
+        createdOn: 0,
+        name: 'Run 1',
+        completed: true,
+      },
+      {
+        id: 2,
+        kind: 'TestRun',
+        projectId: 1,
+        suiteId: 2,
+        createdOn: 0,
+        name: 'Run 2',
+        completed: true,
+      },
+    ];
+    const ignoredSuiteIds = [2];
+
+    const filteredRuns = mockRuns.filter(
+      run => !ignoredSuiteIds.includes(run.suiteId)
+    );
+
+    mockWaitPaged.mockResolvedValue(mockRuns);
+    mockSaveRuns.mockResolvedValue(filteredRuns);
+
+    const result = await syncCompletedRuns({
+      domain: 'test',
+      projectIds: [1],
+      ignoredSuiteIds,
+    });
+
+    expect(waitForPagedLambda).toHaveBeenCalledWith({
+      lambdaFunc: expect.any(Function),
+      args: { domain: 'test', isCompleted: 1, limit: 250 },
+      eventKey: expect.stringContaining('syncCompletedRuns-'),
+      usePage: false,
+      idKey: 'projectId',
+      ids: [1],
+    });
+
+    expect(saveNewRuns).toHaveBeenCalledWith(filteredRuns);
+    expect(mockSetExtensionField).toHaveBeenCalledWith(
+      IDENTIFIER,
+      'lastCompletedRunSync',
+      expect.any(Number)
+    );
+
+    expect(result).toEqual(filteredRuns);
   });
 });

--- a/src/lib/sync/syncRuns.ts
+++ b/src/lib/sync/syncRuns.ts
@@ -11,14 +11,16 @@ const NUM_COMPLETED_RUNS = 250;
 
 type SyncProps = BaseSyncProps & {
   projectIds: number[];
+  ignoredSuiteIds: number[];
 };
 
 export const syncOpenRuns: (props: SyncProps) => Promise<TestRun[]> = async ({
   domain,
   projectIds,
+  ignoredSuiteIds,
 }) => {
   if (!projectIds?.length) {
-    throw new Error('No synced projects found, aborting open test run sync.');
+    return [];
   }
 
   const now = Date.now();
@@ -39,19 +41,21 @@ export const syncOpenRuns: (props: SyncProps) => Promise<TestRun[]> = async ({
     numIds: projectIds.length,
   });
 
-  await saveRecords<TestRun>(openRuns);
+  const runsToSave = openRuns.filter(
+    run => !ignoredSuiteIds.includes(run.suiteId)
+  );
+
+  await saveRecords<TestRun>(runsToSave);
   await aha.account.setExtensionField(IDENTIFIER, 'lastRunSync', now);
 
-  return openRuns;
+  return runsToSave;
 };
 
 export const syncCompletedRuns: (
   props: SyncProps
-) => Promise<TestRun[]> = async ({ domain, projectIds }) => {
+) => Promise<TestRun[]> = async ({ domain, projectIds, ignoredSuiteIds }) => {
   if (!projectIds?.length) {
-    throw new Error(
-      'No synced projects found, aborting completed test run sync.'
-    );
+    return [];
   }
 
   const now = Date.now();
@@ -71,7 +75,11 @@ export const syncCompletedRuns: (
     ids: projectIds,
   });
 
-  const newRuns = await saveNewRuns(completedRuns);
+  const runsToSave = completedRuns.filter(
+    run => !ignoredSuiteIds.includes(run.suiteId)
+  );
+
+  const newRuns = await saveNewRuns(runsToSave);
   await aha.account.setExtensionField(IDENTIFIER, 'lastCompletedRunSync', now);
 
   return newRuns;

--- a/src/lib/sync/syncSections.test.ts
+++ b/src/lib/sync/syncSections.test.ts
@@ -26,10 +26,15 @@ describe('syncSections', () => {
     jest.clearAllMocks();
   });
 
-  it('throws error if no projects found', async () => {
-    await expect(
-      syncSections({ domain: 'test', projectSuites: {} })
-    ).rejects.toThrow('No synced projects found, aborting section sync.');
+  it('early returns if no projects found', async () => {
+    const result = await syncSections({
+      domain: 'test',
+      projectSuites: {},
+      ignoredSuiteIds: [],
+    });
+
+    expect(result).toEqual([]);
+    expect(mockSetExtensionField).not.toHaveBeenCalled();
   });
 
   it('syncs sections without suites', async () => {
@@ -56,6 +61,7 @@ describe('syncSections', () => {
     const result = await syncSections({
       domain: 'test',
       projectSuites: { '100': [] },
+      ignoredSuiteIds: [],
     });
 
     expect(waitForIndexedLambda).toHaveBeenCalledWith({
@@ -105,6 +111,7 @@ describe('syncSections', () => {
         '100': [1, 2],
         '101': [3],
       },
+      ignoredSuiteIds: [],
     });
 
     expect(waitForIndexedLambda).toHaveBeenCalledWith({
@@ -157,6 +164,7 @@ describe('syncSections', () => {
         '101': [],
         '102': [2, 3],
       },
+      ignoredSuiteIds: [],
     });
 
     const { argFunc } = mockWaitIndexed.mock.calls[0][0];
@@ -173,6 +181,7 @@ describe('syncSections', () => {
     const result = await syncSections({
       domain: 'test',
       projectSuites: { '100': [1] },
+      ignoredSuiteIds: [],
     });
 
     expect(saveRecords).toHaveBeenCalledWith([]);
@@ -183,5 +192,47 @@ describe('syncSections', () => {
     );
 
     expect(result).toEqual([]);
+  });
+
+  it('skips syncing sections from ignored suites', async () => {
+    const mockSections = [
+      {
+        id: 1,
+        kind: 'Section',
+        projectId: 100,
+        suiteId: 2,
+        name: 'Section 1',
+      },
+      {
+        id: 2,
+        kind: 'Section',
+        projectId: 100,
+        suiteId: 2,
+        name: 'Section 2',
+      },
+    ];
+
+    mockWaitIndexed.mockResolvedValue(mockSections);
+
+    const result = await syncSections({
+      domain: 'test',
+      projectSuites: { '100': [1, 2] },
+      ignoredSuiteIds: [1],
+    });
+
+    expect(waitForIndexedLambda).toHaveBeenCalledWith({
+      lambdaFunc: expect.any(Function),
+      args: { domain: 'test' },
+      eventKey: expect.stringContaining('syncSections-'),
+      argFunc: expect.any(Function),
+      numIds: 1,
+    });
+
+    const { argFunc } = mockWaitIndexed.mock.calls[0][0];
+
+    expect(argFunc(0)).toEqual({ projectId: '100', suiteId: 2 });
+
+    expect(saveRecords).toHaveBeenCalledWith(mockSections);
+    expect(result).toEqual(mockSections);
   });
 });

--- a/src/lib/sync/syncSections.ts
+++ b/src/lib/sync/syncSections.ts
@@ -6,14 +6,16 @@ type SyncProps = BaseSyncProps & {
   projectSuites: {
     [projectId: string]: number[];
   };
+  ignoredSuiteIds: number[];
 };
 
 const syncSections: (props: SyncProps) => Promise<Section[]> = async ({
   domain,
   projectSuites,
+  ignoredSuiteIds,
 }) => {
   if (Object.keys(projectSuites).length === 0) {
-    throw new Error('No synced projects found, aborting section sync.');
+    return [];
   }
 
   const now = Date.now();
@@ -30,6 +32,8 @@ const syncSections: (props: SyncProps) => Promise<Section[]> = async ({
     }
 
     for (const suiteId of projectSuites[projectId]) {
+      if (ignoredSuiteIds.includes(suiteId)) continue;
+
       lambdaArgs.push({ projectId, suiteId });
     }
   }

--- a/src/lib/sync/syncSuites.test.ts
+++ b/src/lib/sync/syncSuites.test.ts
@@ -26,16 +26,26 @@ describe('syncSuites', () => {
     jest.clearAllMocks();
   });
 
-  it('throws error if no project IDs provided', async () => {
-    await expect(
-      syncSuites({ domain: 'test', projectIds: [] })
-    ).rejects.toThrow('No synced projects found, aborting suite sync.');
+  it('early returns if no project IDs provided', async () => {
+    const result = await syncSuites({
+      domain: 'test',
+      projectIds: [],
+      ignoredSuiteIds: [],
+    });
+
+    expect(result).toEqual([]);
+    expect(mockSetExtensionField).not.toHaveBeenCalled();
   });
 
-  it('throws error if project IDs undefined', async () => {
-    await expect(
-      syncSuites({ domain: 'test', projectIds: undefined })
-    ).rejects.toThrow('No synced projects found, aborting suite sync.');
+  it('early returns if project IDs undefined', async () => {
+    const result = await syncSuites({
+      domain: 'test',
+      projectIds: undefined,
+      ignoredSuiteIds: [],
+    });
+
+    expect(result).toEqual([]);
+    expect(mockSetExtensionField).not.toHaveBeenCalled();
   });
 
   it('syncs and saves suites', async () => {
@@ -56,7 +66,11 @@ describe('syncSuites', () => {
 
     mockWaitIndexed.mockResolvedValue(mockSuites);
 
-    const result = await syncSuites({ domain: 'test', projectIds: [100] });
+    const result = await syncSuites({
+      domain: 'test',
+      projectIds: [100],
+      ignoredSuiteIds: [],
+    });
 
     expect(waitForIndexedLambda).toHaveBeenCalledWith({
       lambdaFunc: expect.any(Function),
@@ -97,6 +111,7 @@ describe('syncSuites', () => {
     const result = await syncSuites({
       domain: 'test',
       projectIds: [100, 101],
+      ignoredSuiteIds: [],
     });
 
     expect(waitForIndexedLambda).toHaveBeenCalledWith({
@@ -120,7 +135,11 @@ describe('syncSuites', () => {
   it('handles empty suite list', async () => {
     mockWaitIndexed.mockResolvedValue([]);
 
-    const result = await syncSuites({ domain: 'test', projectIds: [100] });
+    const result = await syncSuites({
+      domain: 'test',
+      projectIds: [100],
+      ignoredSuiteIds: [],
+    });
 
     expect(saveRecords).toHaveBeenCalledWith([]);
     expect(mockSetExtensionField).toHaveBeenCalledWith(
@@ -130,5 +149,47 @@ describe('syncSuites', () => {
     );
 
     expect(result).toEqual([]);
+  });
+
+  it('does not sync ignored suites', async () => {
+    const mockSuites = [
+      {
+        id: 1,
+        kind: 'Suite',
+        name: 'Suite 1',
+        projectId: 100,
+      },
+      {
+        id: 2,
+        kind: 'Suite',
+        name: 'Suite 2',
+        projectId: 100,
+      },
+    ];
+
+    mockWaitIndexed.mockResolvedValue(mockSuites);
+
+    const result = await syncSuites({
+      domain: 'test',
+      projectIds: [100],
+      ignoredSuiteIds: [1],
+    });
+
+    expect(waitForIndexedLambda).toHaveBeenCalledWith({
+      lambdaFunc: expect.any(Function),
+      argFunc: expect.any(Function),
+      args: { domain: 'test' },
+      eventKey: expect.stringContaining('syncSuites-'),
+      numIds: 1,
+    });
+
+    expect(saveRecords).toHaveBeenCalledWith([mockSuites[1]]);
+    expect(mockSetExtensionField).toHaveBeenCalledWith(
+      IDENTIFIER,
+      'lastSuiteSync',
+      expect.any(Number)
+    );
+
+    expect(result).toEqual([mockSuites[1]]);
   });
 });

--- a/src/lib/sync/syncSuites.ts
+++ b/src/lib/sync/syncSuites.ts
@@ -4,14 +4,16 @@ import { saveRecords } from '../extensionFields/updates';
 
 type SyncProps = BaseSyncProps & {
   projectIds: number[];
+  ignoredSuiteIds: number[];
 };
 
 const syncSuites: (props: SyncProps) => Promise<Suite[]> = async ({
   domain,
   projectIds,
+  ignoredSuiteIds,
 }) => {
   if (!projectIds?.length) {
-    throw new Error('No synced projects found, aborting suite sync.');
+    return [];
   }
 
   const now = Date.now();
@@ -33,10 +35,15 @@ const syncSuites: (props: SyncProps) => Promise<Suite[]> = async ({
     numIds: projectIds.length,
   });
 
-  await saveRecords<Suite>(suites);
+  const visibleSuites = suites.filter(
+    suite => !ignoredSuiteIds.includes(suite.id)
+  );
+
+  await saveRecords<Suite>(visibleSuites);
+
   await aha.account.setExtensionField(IDENTIFIER, 'lastSuiteSync', now);
 
-  return suites;
+  return visibleSuites;
 };
 
 export default syncSuites;

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -35,7 +35,7 @@ export const numberToColor: (color: number) => string = color => {
 // Set the value here to mimic core Aha! behaviour
 const showMessage: (
   msg: string,
-  type: 'danger' | 'warning',
+  type: 'danger' | 'warning' | 'success',
   heading?: string
 ) => void = (msg, type, heading) => {
   const flash = `
@@ -56,6 +56,10 @@ const showMessage: (
 
 export const showError: (msg: string) => void = msg => {
   showMessage(msg, 'danger');
+};
+
+export const showSuccess: (msg: string) => void = msg => {
+  showMessage(msg, 'success');
 };
 
 export const showSyncWarning: () => void = () => {


### PR DESCRIPTION
Add ability to select suites to ignore. Ignoring suites will delete all associated data, and prevent further records from being synced for those suites.

The primary intent of this is to let users exclude automation data, or any other records that wouldn't need to be linked to Aha! features.