### PR TITLE
Update linking modals to use API searching

### DIFF
--- a/src/components/Styles.tsx
+++ b/src/components/Styles.tsx
@@ -183,6 +183,12 @@ export const Styles = () => {
           color: var(--theme-button-danger);
         }
 
+        .search-select {
+          display: flex;
+          align-items: baseline;
+          gap: 20px;
+        }
+
         .search-input {
           padding: var(--spacer-2) var(--spacer-1);
         }
@@ -207,7 +213,7 @@ export const Styles = () => {
           align-items: center;
         }
 
-        .search-row:hover:not(:has(.search-header)) {
+        .search-row:hover:not(:has(.search-header)):not(.disabled) {
           background-color: var(--theme-secondary-background);
           cursor: pointer;
         }

--- a/src/components/modals/ApiSearch.tsx
+++ b/src/components/modals/ApiSearch.tsx
@@ -1,0 +1,269 @@
+import React, { Fragment, useCallback, useMemo, useState, useRef } from 'react';
+import { debounce } from 'lodash';
+import { formatTime } from '../../lib/util';
+import { IDENTIFIER, TestRailRecord } from '../../extension';
+import { fieldName } from '../../lib/extensionFields/queries';
+
+export type TreeNode = {
+  value: string;
+  text: string;
+  date?: number;
+  children?: TreeNode[];
+  header?: boolean;
+  meta?: any;
+};
+
+type CommonProps = {
+  selected: string[];
+  linkedIds: number[];
+  showReference?: boolean;
+  referencePrefix?: string;
+};
+
+type Props = CommonProps & {
+  selected: string[];
+  searchIds: number[];
+  searchKind: TestRailRecord['kind'];
+  searchKey: string;
+  buildTree: (
+    fields: Aha.ExtensionField[],
+    referenceMatches?: number[]
+  ) => Promise<TreeNode[]>;
+  onSelect: (value: string, isSelected: boolean, meta: any) => Promise<void>;
+  recordName: string;
+  loading: boolean;
+  placeholder: string;
+  label: string;
+};
+
+type SectionProps = CommonProps & {
+  tree: TreeNode;
+  query: string;
+  key: string;
+  onSelectBuilder: (
+    value: string,
+    isSelected: boolean,
+    meta: any
+  ) => () => Promise<void>;
+  nesting?: number;
+};
+
+const ResultSection: React.FC<SectionProps> = ({
+  tree,
+  query,
+  selected,
+  linkedIds,
+  key,
+  onSelectBuilder,
+  showReference = true,
+  referencePrefix,
+  nesting = 0,
+}) => {
+  if (tree.children.length === 0) return null;
+
+  const style = { paddingLeft: `${nesting * 20}px` };
+
+  return (
+    <>
+      {(nesting === 0 || tree.header) && (
+        <div key={key} className='search-row' style={style}>
+          <div className='search-header'>{tree.text}</div>
+        </div>
+      )}
+      {tree.children.map(node => {
+        const isSelected = selected.includes(node.value);
+        const isLinked = linkedIds.includes(Number.parseInt(node.value));
+
+        const checked = isSelected || isLinked;
+
+        let onClick: () => void;
+
+        if (isLinked) {
+          onClick = () => {}; // Linked items cannot be toggled
+        } else {
+          onClick = onSelectBuilder(node.value, !checked, node.meta);
+        }
+
+        const searchClass =
+          'search-row' +
+          (checked ? ' selected' : '') +
+          (isLinked ? ' disabled' : '');
+
+        return (
+          <Fragment key={node.value}>
+            {!node.header && (
+              <div
+                key={node.value}
+                className={searchClass}
+                style={style}
+                onClick={onClick}
+              >
+                <div className='search-result'>
+                  <div className='search-column'>
+                    {checked ? (
+                      <aha-icon
+                        class='search-selected'
+                        icon='fa-solid fa-check'
+                      />
+                    ) : (
+                      <aha-icon icon='fa-regular fa-square' />
+                    )}
+
+                    <div className='search-text'>
+                      {showReference && (
+                        <div className='text-light text-gray'>{`${referencePrefix}${node.value}`}</div>
+                      )}
+
+                      <div
+                        className={node.children ? 'search-sub-header' : null}
+                      >
+                        {node.text}
+                      </div>
+                    </div>
+                  </div>
+                  {node.date && (
+                    <div className='text-light text-gray'>
+                      {formatTime(node.date)}
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+            {node.children && (
+              <ResultSection
+                tree={node}
+                query={query}
+                selected={selected}
+                linkedIds={linkedIds}
+                key={node.value}
+                onSelectBuilder={onSelectBuilder}
+                showReference={showReference}
+                referencePrefix={referencePrefix}
+                nesting={nesting + 1}
+              />
+            )}
+          </Fragment>
+        );
+      })}
+    </>
+  );
+};
+
+const ApiSearch: React.FC<Props> = ({
+  selected,
+  searchIds,
+  linkedIds,
+  searchKind,
+  searchKey,
+  onSelect,
+  buildTree,
+  children,
+  recordName,
+  showReference = true,
+  referencePrefix,
+  loading,
+  placeholder,
+  label,
+}) => {
+  const [query, setQuery] = useState<string>('');
+  const [searchResults, setSearchResults] = useState<TreeNode[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const searchNames = useMemo(
+    () => searchIds.map(id => fieldName(searchKind, id)),
+    [searchIds]
+  );
+
+  const search = useCallback(
+    debounce(async () => {
+      if (inputRef.current === null) return;
+
+      const query = inputRef.current.value || '';
+      setQuery(() => query);
+
+      if (query.trim().length === 0 || searchNames.length === 0) {
+        setSearchResults([]);
+        return;
+      }
+
+      const results = await aha.account.searchExtensionFields(
+        IDENTIFIER,
+        searchNames,
+        searchKey,
+        query
+      );
+
+      let referenceMatches = [];
+
+      if (showReference) {
+        const fixedQuery = query.trim().toUpperCase();
+        referenceMatches = searchIds
+          .map(id => `${referencePrefix}${id}`)
+          .filter(reference => reference.includes(fixedQuery));
+      }
+
+      const resultNodes = await buildTree(results, referenceMatches);
+
+      setSearchResults(() => resultNodes);
+    }, 250),
+    [searchNames, showReference, buildTree]
+  );
+
+  const onSelectBuilder: (
+    value: string,
+    isSelected: boolean,
+    meta: any
+  ) => () => Promise<void> = useCallback(
+    (value, isSelected, meta) => async () => {
+      await onSelect(value, isSelected, meta);
+    },
+    [onSelect]
+  );
+
+  return (
+    <>
+      <div className='search-label'>
+        {label}
+        <span className='label-required'>*</span>
+      </div>
+      <div className='search-section'>
+        <div className='search-input'>
+          <input
+            style={{ width: '300px', margin: '0' }}
+            ref={inputRef}
+            type='text'
+            placeholder={`Search by ${recordName} name`}
+            onInput={search}
+          />
+        </div>
+        <div className='search-result-container'>
+          {loading ? (
+            <aha-loading-row class='search-loader' rows={5} columns={2} />
+          ) : query.trim() === '' ? (
+            <div className='search-placeholder'>
+              Start searching to show results
+            </div>
+          ) : searchResults.length === 0 ? (
+            <div className='search-placeholder'>{placeholder}</div>
+          ) : (
+            searchResults.map(header => (
+              <ResultSection
+                tree={header}
+                query={query}
+                selected={selected}
+                linkedIds={linkedIds}
+                key={header.value}
+                onSelectBuilder={onSelectBuilder}
+                showReference={showReference}
+                referencePrefix={referencePrefix}
+              />
+            ))
+          )}
+        </div>
+        {children && <div className='search-footer'>{children}</div>}
+      </div>
+    </>
+  );
+};
+
+export default ApiSearch;

--- a/src/components/modals/LinkTest.tsx
+++ b/src/components/modals/LinkTest.tsx
@@ -1,26 +1,45 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, {
+  useCallback,
+  useState,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
+import { IDENTIFIER, Project, TestRun } from '../../extension';
 import { ExtensionRecord } from '../../lib/extensionRecord';
 import { BulkSyncState } from '../../lib/sync/bulkSync';
-import SelectTestCase from './SelectTestCase';
+import SelectProject from './SelectProject';
+import SelectTestRun from './SelectTestRun';
 import SelectTest from './SelectTest';
-import { linkRecord } from '../../lib/extensionFields/updates';
+import { getRecords } from '../../lib/extensionFields/queries';
+import { linkRecords } from '../../lib/extensionFields/updates';
 
 type Props = {
   record: ExtensionRecord;
   caseIds: number[];
+  testIds: number[];
   syncData: BulkSyncState;
   onClose: () => void;
 };
 
-const LinkTest: React.FC<Props> = ({ record, caseIds, syncData, onClose }) => {
+const LinkTest: React.FC<Props> = ({
+  record,
+  caseIds,
+  testIds,
+  syncData,
+  onClose,
+}) => {
   const modalRef = useRef(null);
   const [saving, setSaving] = useState(false);
 
-  const [caseId, setCaseId] = useState<string>(null);
-  const [testId, setTestId] = useState<string>(null);
-  const [caseStep, setCaseStep] = useState<boolean>(true);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [projectId, setProjectId] = useState<number>(null);
 
-  const testIdRef = useRef(testId);
+  const [run, setRun] = useState<TestRun>(null);
+  const [selected, setSelected] = useState<
+    { caseId: number; testId: number }[]
+  >([]);
+  const [runStep, setRunStep] = useState<boolean>(true);
 
   useEffect(() => {
     const modal = modalRef.current;
@@ -31,22 +50,91 @@ const LinkTest: React.FC<Props> = ({ record, caseIds, syncData, onClose }) => {
     };
   }, []);
 
-  const updateTestId = async value => {
-    testIdRef.current = value;
-    setTestId(value);
-  };
+  useEffect(() => {
+    const fetchProjects = async () => {
+      const projectIds = await aha.account.getExtensionField<number[]>(
+        IDENTIFIER,
+        'projectIds'
+      );
 
-  const submit = async () => {
-    if (!testIdRef.current) return;
+      const fetchedProjects = (
+        await getRecords<Project>(projectIds, 'Project')
+      ).reverse();
 
-    setSaving(true);
+      if (fetchedProjects?.length > 0 && !projectId) {
+        setProjectId(() => fetchedProjects[0].id);
+      }
 
-    await linkRecord(record, Number.parseInt(caseId), 'caseIds');
-    await linkRecord(record, Number.parseInt(testIdRef.current), 'testIds');
+      setProjects(() => fetchedProjects);
+    };
 
-    setSaving(false);
+    fetchProjects();
+  }, []);
+
+  const submit = useCallback(async () => {
+    if (!selected.length) return;
+
+    setSaving(() => true);
+
+    await linkRecords(
+      record,
+      selected.map(({ caseId }) => caseId),
+      'caseIds'
+    );
+
+    await linkRecords(
+      record,
+      selected.map(({ testId }) => testId),
+      'testIds'
+    );
+
+    setSaving(() => false);
     onClose();
-  };
+  }, [record, onClose, selected]);
+
+  const setProject = useCallback(
+    async (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const id = Number.parseInt(e.target.value);
+      setProjectId(() => id);
+      setRun(() => null);
+      setSelected(() => []);
+    },
+    []
+  );
+
+  const updateSelectedRun = useCallback(
+    async (_value: string, isSelected: boolean, meta: TestRun) => {
+      if (!isSelected) {
+        setRun(() => null);
+      } else {
+        setRun(() => meta);
+      }
+
+      setSelected(() => []);
+    },
+    []
+  );
+
+  const selectedRunIds = useMemo(() => {
+    return run ? [run.id.toString()] : [];
+  }, [run]);
+
+  const updateSelected = useCallback(
+    async (value: string, isSelected: boolean, meta: number) => {
+      setSelected(prev => {
+        if (isSelected) {
+          return [...prev, { testId: Number.parseInt(value), caseId: meta }];
+        } else {
+          return prev.filter(item => item.caseId !== meta);
+        }
+      });
+    },
+    [setSelected]
+  );
+
+  const selectedTestIds = useMemo(() => {
+    return selected.map(item => item.testId.toString());
+  }, [selected]);
 
   return (
     <aha-modal ref={modalRef} open position='h-center' size='medium'>
@@ -60,50 +148,60 @@ const LinkTest: React.FC<Props> = ({ record, caseIds, syncData, onClose }) => {
             finished.
           </aha-alert>
         )}
-        <div style={{ display: caseStep ? 'block' : 'none' }}>
-          <SelectTestCase
-            syncData={syncData}
-            caseId={caseId}
-            caseIds={caseIds}
-            setCaseId={async (value: string) => setCaseId(value)}
-          />
+        <div style={{ display: runStep ? 'block' : 'none' }}>
+          <div className='search-form'>
+            <SelectProject
+              projects={projects}
+              projectId={projectId}
+              setProject={setProject}
+            />
+            <SelectTestRun
+              syncData={syncData}
+              runIds={[]}
+              projects={projects}
+              projectId={projectId}
+              selectedRunIds={selectedRunIds}
+              updateSelectedRuns={updateSelectedRun}
+            />
+          </div>
         </div>
-        <div style={{ display: caseStep ? 'none' : 'block' }}>
+        <div style={{ display: runStep ? 'none' : 'block' }}>
           <SelectTest
             syncData={syncData}
-            caseId={caseId}
-            testId={testId}
-            updateTestId={updateTestId}
+            caseIds={caseIds}
+            linkedIds={testIds}
+            selectedTestIds={selectedTestIds}
+            run={run}
+            updateSelectedTestIds={updateSelected}
           />
         </div>
       </aha-modal-body>
       <aha-modal-footer>
-        <div style={{ display: caseStep ? 'block' : 'none' }}>
+        <div style={{ display: runStep ? 'block' : 'none' }}>
           <aha-button
             kind='primary'
-            disabled={!caseId ? true : null}
-            onClick={() => setCaseStep(false)}
+            disabled={!run ? true : null}
+            onClick={() => setRunStep(false)}
           >
             Next
           </aha-button>
         </div>
         <div
           className='search-column'
-          style={{ display: caseStep ? 'none' : 'flex' }}
+          style={{ display: runStep ? 'none' : 'flex' }}
         >
           <aha-button
             kind='primary'
             disabled={saving ? true : null}
             onClick={() => {
-              setCaseStep(true);
-              updateTestId(null);
+              setRunStep(true);
             }}
           >
             Back
           </aha-button>
           <aha-button
             kind='primary'
-            disabled={saving || !testId ? true : null}
+            disabled={saving || !selectedTestIds.length ? true : null}
             onClick={submit}
           >
             {saving ? 'Linking...' : 'Link to test'}

--- a/src/components/modals/LinkTestCase.tsx
+++ b/src/components/modals/LinkTestCase.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useCallback, useEffect, useState, useRef } from 'react';
 import { ExtensionRecord } from '../../lib/extensionRecord';
 import { BulkSyncState } from '../../lib/sync/bulkSync';
 import SelectTestCase from './SelectTestCase';
-import { linkRecord } from '../../lib/extensionFields/updates';
+import { linkRecords } from '../../lib/extensionFields/updates';
 
 type Props = {
   record: ExtensionRecord;
@@ -19,15 +19,8 @@ const LinkTestCase: React.FC<Props> = ({
 }) => {
   const modalRef = useRef(null);
 
-  const [caseId, setCaseId] = useState<string>(null);
+  const [selectedCaseIds, setSelectedCaseIds] = useState<string[]>([]);
   const [saving, setSaving] = useState(false);
-
-  const caseIdRef = useRef<string>(null);
-
-  const updateCaseId = async (value: string) => {
-    caseIdRef.current = value;
-    setCaseId(value);
-  };
 
   useEffect(() => {
     const modal = modalRef.current;
@@ -38,16 +31,42 @@ const LinkTestCase: React.FC<Props> = ({
     };
   }, [onClose]);
 
-  const submit = async () => {
-    if (!caseIdRef.current) return;
+  const submit = useCallback(async () => {
+    setSaving(() => true);
 
-    setSaving(true);
+    await linkRecords(
+      record,
+      selectedCaseIds.map(id => Number.parseInt(id)),
+      'caseIds'
+    );
 
-    await linkRecord(record, Number.parseInt(caseIdRef.current), 'caseIds');
-
-    setSaving(false);
+    setSaving(() => false);
     onClose();
-  };
+  }, [record, selectedCaseIds, onClose]);
+
+  const updateSelectedCaseIds: (
+    value: string,
+    isSelected: boolean
+  ) => Promise<void> = useCallback(
+    async (value: string, isSelected: boolean) => {
+      setSelectedCaseIds(prev => {
+        if (caseIds.includes(Number.parseInt(value))) {
+          return prev;
+        }
+
+        if (isSelected) {
+          return [...prev, value];
+        } else {
+          return prev.filter(id => id !== value);
+        }
+      });
+    },
+    [caseIds]
+  );
+
+  const clearSelectedCaseIds = useCallback(() => {
+    setSelectedCaseIds(() => []);
+  }, []);
 
   return (
     <aha-modal ref={modalRef} open position='h-center' size='medium'>
@@ -66,14 +85,15 @@ const LinkTestCase: React.FC<Props> = ({
         <SelectTestCase
           caseIds={caseIds}
           syncData={syncData}
-          caseId={caseId}
-          setCaseId={updateCaseId}
+          selectedCaseIds={selectedCaseIds}
+          updateSelectedCaseIds={updateSelectedCaseIds}
+          clearSelectedCaseIds={clearSelectedCaseIds}
         />
       </aha-modal-body>
       <aha-modal-footer>
         <aha-button
           kind='primary'
-          disabled={saving || !caseId ? true : null}
+          disabled={saving || !selectedCaseIds.length ? true : null}
           onClick={submit}
         >
           {saving ? 'Linking...' : 'Link to test case'}

--- a/src/components/modals/LinkTestRun.tsx
+++ b/src/components/modals/LinkTestRun.tsx
@@ -1,115 +1,17 @@
-import React, { useEffect, useState, useRef } from 'react';
-import { IDENTIFIER, Project, TestRun } from '../../extension';
+import React, { useCallback, useEffect, useState, useRef } from 'react';
+import { IDENTIFIER, Project } from '../../extension';
 import { ExtensionRecord } from '../../lib/extensionRecord';
-import SearchByName, { TreeNode } from './SearchByName';
-import {
-  getRecords,
-  getProjectRecords,
-} from '../../lib/extensionFields/queries';
-import { linkRecord } from '../../lib/extensionFields/updates';
-import { BulkSyncState, SyncStage, SyncState } from '../../lib/sync/bulkSync';
-import SyncProgress from '../SyncProgress';
+import { getRecords } from '../../lib/extensionFields/queries';
+import { linkRecords } from '../../lib/extensionFields/updates';
+import { BulkSyncState } from '../../lib/sync/bulkSync';
+import SelectProject from './SelectProject';
+import SelectTestRun from './SelectTestRun';
 
 type Props = {
   record: ExtensionRecord;
   runIds: number[] | undefined;
   syncData: BulkSyncState;
   onClose: () => void;
-};
-
-const runOptions: (
-  projects: Project[],
-  runMapping: {
-    [projectId: string]: TestRun[];
-  },
-  runIds: number[]
-) => TreeNode[] = (projects, runMapping, runIds) => {
-  const options: TreeNode[] = [];
-
-  let idMapping: { [runId: number]: boolean } = [];
-
-  if (runIds && runIds.length) {
-    idMapping = runIds.reduce((acc, id) => {
-      acc[id] = true;
-      return acc;
-    }, {});
-  }
-
-  for (const project of projects) {
-    const runs = runMapping[project.id] || [];
-
-    const openRuns = [];
-    const completedRuns = [];
-
-    for (const run of runs) {
-      if (idMapping[run.id]) continue;
-
-      if (run.completed) {
-        completedRuns.push(run);
-      } else {
-        openRuns.push(run);
-      }
-    }
-
-    let openHeader: TreeNode = null;
-    let completedHeader: TreeNode = null;
-
-    if (openRuns.length) {
-      openHeader = {
-        value: project.id.toString(),
-        text: 'Open runs',
-        header: true,
-        children: openRuns.map(r => ({
-          text: r.name,
-          value: `${r.id}`,
-          date: r.createdOn * 1000,
-        })),
-      };
-    }
-
-    if (completedRuns.length) {
-      completedHeader = {
-        value: project.id.toString(),
-        text: 'Completed runs',
-        header: true,
-        children: completedRuns.map(r => ({
-          text: r.name,
-          value: `${r.id}`,
-          date: r.createdOn * 1000,
-        })),
-      };
-    }
-
-    const children = [openHeader, completedHeader].filter(Boolean);
-
-    if (children.length === 0) continue;
-
-    const header: TreeNode = {
-      value: project.id.toString(),
-      text: project.name,
-      children,
-    };
-
-    options.push(header);
-  }
-
-  return options;
-};
-
-const findChild: (node: TreeNode, value: string) => boolean = (node, value) => {
-  if (node.value === value) {
-    return true;
-  }
-
-  if (!node.children) return false;
-
-  for (const child of node.children) {
-    if (findChild(child, value)) {
-      return true;
-    }
-  }
-
-  return false;
 };
 
 const LinkTestRun: React.FC<Props> = ({
@@ -119,69 +21,11 @@ const LinkTestRun: React.FC<Props> = ({
   onClose,
 }) => {
   const modalRef = useRef(null);
-  const runIdRef = useRef(null);
 
-  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-
-  const [syncing, setSyncing] = useState(null);
-  const [syncStage, setSyncStage] = useState(syncData?.stage);
-
-  const [runId, setRunId] = useState<string>(null);
-  const [runTree, setRunTree] = useState<TreeNode[]>([]);
-
-  const updateRunId = async value => {
-    runIdRef.current = value; // Use this as a cache, the state is not updated immediately
-    setRunId(value);
-  };
-
-  const submit = async () => {
-    if (!runIdRef.current) return;
-
-    setSaving(true);
-
-    await linkRecord(record, Number.parseInt(runIdRef.current), 'runIds');
-
-    setSaving(false);
-    onClose();
-  };
-
-  useEffect(() => {
-    const fetchRuns = async () => {
-      const projectIds = await aha.account.getExtensionField<number[]>(
-        IDENTIFIER,
-        'projectIds'
-      );
-
-      const [runMapping, projects] = await Promise.all([
-        getProjectRecords<TestRun>(projectIds, 'TestRun'),
-        getRecords<Project>(projectIds, 'Project'),
-      ]);
-
-      setRunTree(runOptions(projects, runMapping, runIds));
-      setLoading(false);
-    };
-
-    if (syncData && syncing === null) {
-      setSyncing(syncData.state !== SyncState.Complete);
-    }
-
-    const lastStage = syncStage;
-    let currentStage = syncStage;
-
-    if (syncData) {
-      currentStage = syncData.stage;
-      setSyncStage(currentStage);
-    }
-
-    const syncedRuns =
-      lastStage &&
-      lastStage >= SyncStage.OpenRuns &&
-      lastStage <= SyncStage.CompletedPlans &&
-      lastStage !== currentStage;
-
-    if (loading || syncedRuns) fetchRuns();
-  }, [syncData]);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [projectId, setProjectId] = useState<number>(null);
+  const [selectedRunIds, setSelectedRunIds] = useState<string[]>([]);
 
   useEffect(() => {
     const modal = modalRef.current;
@@ -191,6 +35,71 @@ const LinkTestRun: React.FC<Props> = ({
       modal.removeEventListener('aha-modal:close', onClose);
     };
   }, [onClose]);
+
+  useEffect(() => {
+    const fetchProjects = async () => {
+      const projectIds = await aha.account.getExtensionField<number[]>(
+        IDENTIFIER,
+        'projectIds'
+      );
+
+      const fetchedProjects = (
+        await getRecords<Project>(projectIds, 'Project')
+      ).reverse();
+
+      if (fetchedProjects?.length > 0 && !projectId) {
+        setProjectId(() => fetchedProjects[0].id);
+      }
+
+      setProjects(() => fetchedProjects);
+    };
+
+    fetchProjects();
+  }, []);
+
+  const submit = useCallback(async () => {
+    if (!selectedRunIds.length) return;
+
+    setSaving(() => true);
+
+    await linkRecords(
+      record,
+      selectedRunIds.map(id => Number.parseInt(id)),
+      'runIds'
+    );
+
+    setSaving(() => false);
+    onClose();
+  }, [selectedRunIds, record, onClose]);
+
+  const setProject = useCallback(
+    async (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const id = Number.parseInt(e.target.value);
+      setProjectId(() => id);
+      setSelectedRunIds(() => []);
+    },
+    []
+  );
+
+  const updateSelectedRuns: (
+    value: string,
+    isSelected: boolean
+  ) => Promise<void> = useCallback(
+    async (value: string, isSelected: boolean) => {
+      setSelectedRunIds(prev => {
+        if (runIds.includes(Number.parseInt(value))) {
+          return prev;
+        }
+
+        if (isSelected) {
+          return [...prev, value];
+        } else {
+          return prev.filter(id => id !== value);
+        }
+      });
+    },
+    [runIds]
+  );
 
   return (
     <aha-modal ref={modalRef} open position='h-center' size='medium'>
@@ -207,25 +116,25 @@ const LinkTestRun: React.FC<Props> = ({
           </aha-alert>
         )}
         <div className='search-form'>
-          <SearchByName
-            tree={runTree}
-            selected={[runId]}
-            onSelect={updateRunId}
-            recordName='test run'
-            showReference={true}
-            referencePrefix='R'
-            loading={loading}
-            label='Select a test run'
-            placeholder='No synced test runs found.'
-          >
-            {syncing && <SyncProgress syncData={syncData} />}
-          </SearchByName>
+          <SelectProject
+            projects={projects}
+            projectId={projectId}
+            setProject={setProject}
+          />
+          <SelectTestRun
+            syncData={syncData}
+            runIds={runIds}
+            projects={projects}
+            projectId={projectId}
+            selectedRunIds={selectedRunIds}
+            updateSelectedRuns={updateSelectedRuns}
+          />
         </div>
       </aha-modal-body>
       <aha-modal-footer>
         <aha-button
           kind='primary'
-          disabled={loading || saving || !runId ? true : null}
+          disabled={saving || !selectedRunIds.length ? true : null}
           onClick={submit}
         >
           {saving ? 'Linking...' : 'Link test run'}

--- a/src/components/modals/LinkTestToTestCase.tsx
+++ b/src/components/modals/LinkTestToTestCase.tsx
@@ -5,7 +5,7 @@ import React, {
   useState,
   useRef,
 } from 'react';
-import { IDENTIFIER, Project, Test, TestCase } from '../../extension';
+import { IDENTIFIER, Project, Test, TestCase, TestRun } from '../../extension';
 import { BulkSyncState } from '../../lib/sync/bulkSync';
 import { ExtensionRecord } from '../../lib/extensionRecord';
 import {
@@ -73,6 +73,15 @@ const LinkTestToTestCase: React.FC<Props> = ({
     []
   );
 
+  // We can filter out runs that don't match the test case's suite or were created
+  // before the test case was created.
+  // This should reduce the chance of showing a run that doesn't have a matching test for the case.
+  const filterRuns = useCallback(
+    (run: TestRun) =>
+      run.suiteId === testCase.suiteId && run.createdOn >= testCase.createdOn,
+    [testCase]
+  );
+
   const submit = useCallback(async () => {
     if (!runId) return;
 
@@ -85,7 +94,7 @@ const LinkTestToTestCase: React.FC<Props> = ({
 
     if (!testIds || !testIds.length) {
       setSaving(() => false);
-      setError(() => 'No test results found for the selected run');
+      setError(() => 'No test results found for the selected run.');
       return;
     }
 
@@ -94,7 +103,10 @@ const LinkTestToTestCase: React.FC<Props> = ({
 
     if (!testId) {
       setSaving(() => false);
-      setError(() => 'Selected run has no results for linked test case');
+      setError(
+        () =>
+          'Selected run has no results for linked test case. Please choose a different run.'
+      );
       return;
     }
 
@@ -133,6 +145,7 @@ const LinkTestToTestCase: React.FC<Props> = ({
             projectId={testCase.projectId}
             selectedRunIds={selectedRunIds}
             updateSelectedRuns={updateSelectedRun}
+            filter={filterRuns}
           />
         </div>
       </aha-modal-body>

--- a/src/components/modals/LinkTestToTestCase.tsx
+++ b/src/components/modals/LinkTestToTestCase.tsx
@@ -1,9 +1,19 @@
-import React, { useEffect, useState, useRef } from 'react';
-import { TestCase } from '../../extension';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useRef,
+} from 'react';
+import { IDENTIFIER, Project, Test, TestCase } from '../../extension';
 import { BulkSyncState } from '../../lib/sync/bulkSync';
 import { ExtensionRecord } from '../../lib/extensionRecord';
+import {
+  getRecords,
+  indexKeyForKindAndParent,
+} from '../../lib/extensionFields/queries';
 import { linkRecord } from '../../lib/extensionFields/updates';
-import SelectTest from './SelectTest';
+import SelectTestRun from './SelectTestRun';
 
 type Props = {
   record: ExtensionRecord;
@@ -20,9 +30,24 @@ const LinkTestToTestCase: React.FC<Props> = ({
 }) => {
   const modalRef = useRef(null);
   const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [projects, setProjects] = useState<Project[]>([]);
 
-  const [testId, setTestId] = useState<string>(null);
-  const testIdRef = useRef(testId);
+  const [runId, setRunId] = useState<string>(null);
+
+  useEffect(() => {
+    const fetchProjects = async () => {
+      const projectIds = await aha.account.getExtensionField<number[]>(
+        IDENTIFIER,
+        'projectIds'
+      );
+
+      const fetchedProjects = await getRecords<Project>(projectIds, 'Project');
+      setProjects(() => fetchedProjects);
+    };
+
+    fetchProjects();
+  }, []);
 
   useEffect(() => {
     const modal = modalRef.current;
@@ -33,21 +58,52 @@ const LinkTestToTestCase: React.FC<Props> = ({
     };
   }, []);
 
-  const updateTestId = async value => {
-    testIdRef.current = value;
-    setTestId(value);
-  };
+  const selectedRunIds = useMemo(() => {
+    return runId ? [runId] : [];
+  }, [runId]);
 
-  const submit = async () => {
-    if (!testIdRef.current) return;
+  const updateSelectedRun = useCallback(
+    async (value: string, isSelected: boolean) => {
+      if (!isSelected) {
+        setRunId(() => null);
+      } else {
+        setRunId(() => value);
+      }
+    },
+    []
+  );
 
-    setSaving(true);
+  const submit = useCallback(async () => {
+    if (!runId) return;
 
-    await linkRecord(record, Number.parseInt(testIdRef.current), 'testIds');
+    setSaving(() => true);
 
-    setSaving(false);
+    const testIds = await aha.account.getExtensionField<number[]>(
+      IDENTIFIER,
+      indexKeyForKindAndParent('Test', Number.parseInt(runId))
+    );
+
+    if (!testIds || !testIds.length) {
+      setSaving(() => false);
+      setError(() => 'No test results found for the selected run');
+      return;
+    }
+
+    const tests = await getRecords<Test>(testIds, 'Test');
+    const testId = tests.find(test => test.caseId === testCase.id)?.id;
+
+    if (!testId) {
+      setSaving(() => false);
+      setError(() => 'Selected run has no results for linked test case');
+      return;
+    }
+
+    await linkRecord(record, testId, 'testIds');
+
+    setSaving(() => false);
+    setError(() => null);
     onClose();
-  };
+  }, [record, runId, testCase]);
 
   return (
     <aha-modal ref={modalRef} open position='h-center' size='medium'>
@@ -63,17 +119,27 @@ const LinkTestToTestCase: React.FC<Props> = ({
             finished.
           </aha-alert>
         )}
-        <SelectTest
-          caseId={testCase.id.toString()}
-          syncData={syncData}
-          testId={testId}
-          updateTestId={updateTestId}
-        />
+        {error && (
+          <aha-alert class='mb-5' type='danger'>
+            <div slot='heading'>Error linking test case to test</div>
+            {error}
+          </aha-alert>
+        )}
+        <div className='search-form'>
+          <SelectTestRun
+            syncData={syncData}
+            runIds={[]}
+            projects={projects}
+            projectId={testCase.projectId}
+            selectedRunIds={selectedRunIds}
+            updateSelectedRuns={updateSelectedRun}
+          />
+        </div>
       </aha-modal-body>
       <aha-modal-footer>
         <aha-button
           kind='primary'
-          disabled={saving || !testId ? true : null}
+          disabled={saving || !runId ? true : null}
           onClick={submit}
         >
           {saving ? 'Linking...' : 'Link to test'}

--- a/src/components/modals/SelectProject.tsx
+++ b/src/components/modals/SelectProject.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Project } from '../../extension';
+
+type Props = {
+  projects: Project[];
+  projectId: number;
+  setProject: (event: React.ChangeEvent<HTMLSelectElement>) => void;
+};
+
+const SelectProject: React.FC<Props> = ({
+  projects,
+  projectId,
+  setProject,
+}) => {
+  return (
+    <div className='search-select'>
+      <div className='search-label'>
+        Project
+        <span className='label-required'>*</span>
+      </div>
+      <select name='project' onChange={setProject} style={{ width: '100%' }}>
+        {projects.map(project => (
+          <option
+            key={project.id}
+            value={project.id}
+            selected={projectId === project.id}
+          >
+            {project.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};
+
+export default SelectProject;

--- a/src/components/modals/SelectTest.tsx
+++ b/src/components/modals/SelectTest.tsx
@@ -1,76 +1,61 @@
-import React, { useEffect, useState } from 'react';
-import { TestCase, Test } from '../../extension';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { IDENTIFIER, Test, TestCase, TestRun } from '../../extension';
 import { BulkSyncState, SyncStage, SyncState } from '../../lib/sync/bulkSync';
-import SearchByName, { TreeNode } from './SearchByName';
-import { getRunMapForTestCase } from '../../lib/extensionFields/queries';
+import ApiSearch, { TreeNode } from './ApiSearch';
+import { indexKeyForKindAndParent } from '../../lib/extensionFields/queries';
 import SyncProgress from '../SyncProgress';
 import { getRecords } from '../../lib/extensionFields/queries';
 
 type Props = {
-  caseId: string;
+  run: TestRun;
+  caseIds: number[];
+  linkedIds: number[];
   syncData: BulkSyncState;
-  testId: string;
-  updateTestId: (value: string) => Promise<void>;
+  selectedTestIds: string[];
+  updateSelectedTestIds: (
+    testId: string,
+    isSelected: boolean,
+    meta?: any
+  ) => Promise<void>;
 };
 
-// The tree displays runs, because there's no identifying data to separate
-// tests for the same case, and a run will have at most one test per test case.
-const runOptions: (
-  testCase: TestCase,
-  runMapping: [Test, string, number][]
-) => TreeNode[] = (testCase, runMapping) => {
-  const children = runMapping.map(([test, runName, createdOn]) => ({
-    value: test.id.toString(),
-    text: runName,
-    date: createdOn * 1000,
-  }));
-
-  if (children.length === 0) return [];
-
-  return [
-    {
-      value: testCase.id.toString(),
-      text: testCase.title,
-      children,
-    },
-  ];
-};
-
+// Given a test run, allows you to select multiple tests for that run
 const SelectTest: React.FC<Props> = ({
-  caseId,
+  run,
+  caseIds,
+  linkedIds,
   syncData,
-  testId,
-  updateTestId,
+  selectedTestIds,
+  updateSelectedTestIds,
 }) => {
   const [loading, setLoading] = useState(true);
   const [syncing, setSyncing] = useState(null);
   const [syncingTests, setSyncingTests] = useState(false);
 
-  const [runTree, setRunTree] = useState<TreeNode[]>([]);
+  const [lastRunId, setLastRunId] = useState<number>(run?.id);
+  const [tests, setTests] = useState<Test[]>([]);
 
-  const [savedCaseId, setSavedCaseId] = useState<string>(caseId);
+  const [searchIds, setSearchIds] = useState<number[]>([]);
 
   useEffect(() => {
-    const fetchRuns = async () => {
-      const [testCase] = await getRecords<TestCase>(
-        [Number.parseInt(caseId)],
-        'TestCase'
+    const fetchTests = async () => {
+      if (!run) return;
+
+      const testIds = await aha.account.getExtensionField<number[]>(
+        IDENTIFIER,
+        indexKeyForKindAndParent('Test', run.id)
       );
 
-      const runMapping = await getRunMapForTestCase(testCase);
+      const fetchedTests = await getRecords<Test>(testIds, 'Test');
+      setTests(() => fetchedTests);
 
-      setRunTree(runOptions(testCase, runMapping));
-      setLoading(false);
+      // Tests don't have a name/title, so we use test cases for search
+      setSearchIds(() => fetchedTests.map(test => test.caseId));
+      setLoading(() => false);
     };
 
-    const caseIdChanged = caseId !== savedCaseId;
-
-    if (caseIdChanged) {
-      setSavedCaseId(caseId);
-    }
-
     if (syncData && syncing === null) {
-      setSyncing(syncData.state !== SyncState.Complete);
+      setSyncing(() => syncData.state !== SyncState.Complete);
     }
 
     const lastState = syncingTests;
@@ -78,34 +63,115 @@ const SelectTest: React.FC<Props> = ({
 
     if (syncData) {
       currentState = syncData.stage <= SyncStage.Tests;
-      setSyncingTests(currentState);
+      setSyncingTests(() => currentState);
     }
+
+    const runIdChanged = lastRunId !== run?.id;
+    if (runIdChanged) setLastRunId(() => run?.id);
 
     // Load on first render if caseId changes, or if new tests potentially synced
     const shouldLoad =
-      caseId && (loading || caseIdChanged || (lastState && !currentState));
+      run && (loading || runIdChanged || (lastState && !currentState));
 
-    if (caseId && caseIdChanged) {
-      setLoading(true);
+    if (run && runIdChanged) {
+      setLoading(() => true);
     }
 
-    if (shouldLoad) fetchRuns();
-  }, [caseId, syncData]);
+    if (shouldLoad) fetchTests();
+  }, [run, syncData]);
+
+  const caseIdsSet = useMemo(() => new Set(caseIds), [caseIds]);
+  const linkedIdsSet = useMemo(() => new Set(linkedIds), [linkedIds]);
+
+  const buildTree: (
+    fields: Aha.ExtensionField[],
+    referenceMatches: number[]
+  ) => Promise<TreeNode[]> = useCallback(
+    async (fields, referenceMatches) => {
+      const matchedCases = fields.map(field => field.value as TestCase);
+
+      const caseMap: { [caseId: number]: TestCase } = matchedCases.reduce(
+        (map, testCase) => {
+          map[testCase.id] = testCase;
+          return map;
+        },
+        {}
+      );
+
+      let children = tests.filter(test => caseMap[test.caseId]);
+
+      const referenceMatchedTests = new Set(
+        referenceMatches.filter(id => !children.some(child => child.id === id))
+      );
+
+      if (referenceMatchedTests.size > 0) {
+        const records = tests.filter(test =>
+          referenceMatchedTests.has(test.id)
+        );
+
+        const casesToFetch = [];
+        records.forEach(test => {
+          if (!caseMap[test.caseId]) {
+            casesToFetch.push(test.caseId);
+          }
+        });
+
+        const cases = await getRecords<TestCase>(casesToFetch, 'TestCase');
+
+        children = children.concat(records);
+        cases.forEach(testCase => {
+          caseMap[testCase.id] = testCase;
+        });
+      }
+
+      // If a match is for a linked test, show it as linked, but if
+      // a match is for a linked case and an unknown test, hide it so the user can't
+      // overwrite their linked tests.
+      children = children.filter(
+        test => linkedIdsSet.has(test.id) || !caseIdsSet.has(test.caseId)
+      );
+
+      children.sort((a, b) => b.id - a.id);
+
+      const nodes = children.map(record => ({
+        value: record.id.toString(),
+        text: caseMap[record.caseId]?.title,
+        meta: record.caseId,
+      }));
+
+      if (!run || nodes.length === 0) {
+        return [];
+      }
+
+      return [
+        {
+          value: run.id.toString(),
+          text: run.name,
+          children: nodes,
+        },
+      ];
+    },
+    [run, tests]
+  );
 
   return (
     <div className='search-form'>
-      <SearchByName
-        tree={runTree}
-        selected={[testId]}
-        onSelect={updateTestId}
+      <ApiSearch
+        searchIds={searchIds}
+        selected={selectedTestIds}
+        linkedIds={linkedIds}
+        searchKind={'TestCase'}
+        searchKey={'title'}
+        onSelect={updateSelectedTestIds}
+        buildTree={buildTree}
         recordName='test'
         referencePrefix='T'
         loading={loading}
         label='Select a test'
-        placeholder='No tests found for this test case.'
+        placeholder='No synced tests found.'
       >
         {syncing && <SyncProgress syncData={syncData} />}
-      </SearchByName>
+      </ApiSearch>
     </div>
   );
 };

--- a/src/components/modals/SelectTestCase.tsx
+++ b/src/components/modals/SelectTestCase.tsx
@@ -1,90 +1,69 @@
-import React, { useEffect, useState } from 'react';
-import SearchByName, { TreeNode } from './SearchByName';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import ApiSearch, { TreeNode } from './ApiSearch';
 import SyncProgress from '../SyncProgress';
 import { IDENTIFIER, Project, TestCase } from '../../extension';
 import {
+  getAccountExtensionFieldMap,
   getRecords,
-  getProjectRecords,
+  indexKeyForKindAndParent,
 } from '../../lib/extensionFields/queries';
 import { BulkSyncState, SyncStage, SyncState } from '../../lib/sync/bulkSync';
+import SelectProject from './SelectProject';
 
 type Props = {
   syncData: BulkSyncState;
-  caseId: string;
+  selectedCaseIds: string[];
   caseIds: number[];
-  setCaseId: (caseId: string) => Promise<void>;
-};
-
-const caseOptions: (
-  projects: Project[],
-  caseMapping: {
-    [projectId: string]: TestCase[];
-  },
-  caseIds: number[]
-) => TreeNode[] = (projects, caseMapping, caseIds) => {
-  const options: TreeNode[] = [];
-  let idMapping: { [caseId: number]: boolean } = [];
-
-  if (caseIds && caseIds.length) {
-    idMapping = caseIds.reduce((acc, id) => {
-      acc[id] = true;
-      return acc;
-    }, {});
-  }
-
-  for (const project of projects) {
-    const cases = caseMapping[project.id] || [];
-
-    const filteredCases = cases.filter(c => !idMapping[c.id]);
-
-    if (filteredCases.length === 0) continue;
-
-    const header: TreeNode = {
-      value: project.id.toString(),
-      text: project.name,
-      children: filteredCases.map(c => ({
-        text: c.title,
-        value: `${c.id}`,
-        date: c.createdOn * 1000,
-      })),
-    };
-
-    options.push(header);
-  }
-
-  return options;
+  updateSelectedCaseIds: (caseId: string, isSelected: boolean) => Promise<void>;
+  clearSelectedCaseIds: () => void;
 };
 
 const SelectTestCase: React.FC<Props> = ({
   syncData,
-  caseId,
+  selectedCaseIds,
   caseIds,
-  setCaseId,
+  updateSelectedCaseIds,
+  clearSelectedCaseIds,
 }) => {
   const [loading, setLoading] = useState(true);
   const [syncing, setSyncing] = useState(null); // True if syncing on initial load
   const [syncingCases, setSyncingCases] = useState(false); // True if there may be new cases to sync
 
-  const [caseTree, setCaseTree] = useState<TreeNode[]>([]);
+  const [projectId, setProjectId] = useState<number>();
+  const [projects, setProjects] = useState<Project[]>([]);
+
+  const [searchMapping, setSearchMapping] = useState<{
+    [projectId: number]: number[];
+  }>({});
 
   useEffect(() => {
-    const fetchCases = async () => {
+    const fetchSearchKeys = async () => {
       const projectIds = await aha.account.getExtensionField<number[]>(
         IDENTIFIER,
         'projectIds'
       );
 
-      const [caseMapping, projects] = await Promise.all([
-        getProjectRecords<TestCase>(projectIds, 'TestCase'),
-        getRecords<Project>(projectIds, 'Project'),
-      ]);
+      const fetchedProjects = (
+        await getRecords<Project>(projectIds, 'Project')
+      ).reverse();
 
-      setCaseTree(caseOptions(projects, caseMapping, caseIds));
-      setLoading(false);
+      if (fetchedProjects?.length > 0 && !projectId) {
+        setProjectId(() => fetchedProjects[0].id);
+      }
+
+      const keys = fetchedProjects.map(project =>
+        indexKeyForKindAndParent('TestCase', project.id)
+      );
+
+      const mapping = await getAccountExtensionFieldMap<number[]>(keys);
+      setSearchMapping(() => mapping);
+
+      setProjects(() => fetchedProjects);
+      setLoading(() => false);
     };
 
     if (syncData && syncing === null) {
-      setSyncing(syncData.state !== SyncState.Complete);
+      setSyncing(() => syncData.state !== SyncState.Complete);
     }
 
     const lastState = syncingCases;
@@ -92,19 +71,84 @@ const SelectTestCase: React.FC<Props> = ({
 
     if (syncData) {
       currentState = syncData.stage <= SyncStage.TestCases;
-      setSyncingCases(currentState);
+      setSyncingCases(() => currentState);
     }
 
     // Fetch data on first load or if new cases potentially synced
-    if (loading || (lastState && !currentState)) fetchCases();
+    if (loading || (lastState && !currentState)) fetchSearchKeys();
   }, [syncData]);
+
+  const setProject: (e: React.ChangeEvent<HTMLSelectElement>) => Promise<void> =
+    useCallback(
+      async event => {
+        const id = Number.parseInt(event.target.value);
+        setProjectId(() => id);
+        clearSelectedCaseIds();
+      },
+      [clearSelectedCaseIds]
+    );
+
+  const buildTree: (
+    fields: Aha.ExtensionField[],
+    referenceMatches: number[]
+  ) => Promise<TreeNode[]> = useCallback(
+    async (fields, referenceMatches) => {
+      let children = fields.map(field => field.value as TestCase);
+
+      const casesToFetch = referenceMatches.filter(
+        id => !children.some(child => child.id === id)
+      );
+
+      if (casesToFetch.length > 0) {
+        const records = await getRecords<TestCase>(casesToFetch, 'TestCase');
+        children = children.concat(records);
+      }
+
+      children.sort((a, b) => b.id - a.id);
+
+      const nodes = children.map(record => ({
+        value: record.id.toString(),
+        text: record.title,
+        date: record.createdOn * 1000,
+      }));
+
+      const project = projects.find(p => p.id === projectId);
+
+      if (!project || nodes.length === 0) {
+        return [];
+      }
+
+      return [
+        {
+          value: projectId.toString(),
+          text: project.name,
+          children: nodes,
+        },
+      ];
+    },
+    [projects, projectId]
+  );
+
+  const searchIds = useMemo(
+    () => searchMapping[indexKeyForKindAndParent('TestCase', projectId)] || [],
+    [searchMapping, projectId]
+  );
 
   return (
     <div className='search-form'>
-      <SearchByName
-        tree={caseTree}
-        selected={[caseId]}
-        onSelect={setCaseId}
+      <SelectProject
+        projects={projects}
+        projectId={projectId}
+        setProject={setProject}
+      />
+      <ApiSearch
+        searchIds={searchIds}
+        selected={selectedCaseIds}
+        linkedIds={caseIds}
+        searchKind={'TestCase'}
+        searchKey={'title'}
+        onSelect={updateSelectedCaseIds}
+        buildTree={buildTree}
         recordName='test case'
         referencePrefix='C'
         loading={loading}
@@ -112,7 +156,7 @@ const SelectTestCase: React.FC<Props> = ({
         placeholder='No synced test cases found.'
       >
         {syncing && <SyncProgress syncData={syncData} />}
-      </SearchByName>
+      </ApiSearch>
     </div>
   );
 };

--- a/src/components/modals/SelectTestRun.tsx
+++ b/src/components/modals/SelectTestRun.tsx
@@ -1,0 +1,155 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import ApiSearch, { TreeNode } from './ApiSearch';
+import SyncProgress from '../SyncProgress';
+import { Project, TestRun } from '../../extension';
+import {
+  getAccountExtensionFieldMap,
+  getRecords,
+  indexKeyForKindAndParent,
+} from '../../lib/extensionFields/queries';
+import { BulkSyncState, SyncStage, SyncState } from '../../lib/sync/bulkSync';
+
+type Props = {
+  syncData: BulkSyncState;
+  selectedRunIds: string[];
+  runIds: number[];
+  projects: Project[];
+  projectId: number;
+  updateSelectedRuns: (
+    runId: string,
+    isSelected: boolean,
+    meta?: any
+  ) => Promise<void>;
+};
+
+const SelectTestRun: React.FC<Props> = ({
+  syncData,
+  selectedRunIds,
+  runIds,
+  projects,
+  projectId,
+  updateSelectedRuns,
+}) => {
+  const [loading, setLoading] = useState(true);
+  const [syncing, setSyncing] = useState(null); // True if syncing on initial load
+  const [syncStage, setSyncStage] = useState(syncData?.stage);
+
+  const [searchMapping, setSearchMapping] = useState<{
+    [projectId: number]: number[];
+  }>({});
+
+  useEffect(() => {
+    const fetchSearchKeys = async () => {
+      const keys = projects.map(project =>
+        indexKeyForKindAndParent('TestRun', project.id)
+      );
+
+      const mapping = await getAccountExtensionFieldMap<number[]>(keys);
+      setSearchMapping(() => mapping);
+      console.log('Search mapping:', mapping);
+      setLoading(() => false);
+    };
+
+    let shouldFetch = loading;
+
+    if (
+      projects.length >= 0 &&
+      !shouldFetch &&
+      Object.keys(searchMapping).length === 0
+    ) {
+      shouldFetch = true;
+    }
+
+    if (syncData && syncing === null) {
+      setSyncing(() => syncData.state !== SyncState.Complete);
+    }
+
+    const lastStage = syncStage;
+    let currentStage = syncStage;
+
+    if (syncData) {
+      currentStage = syncData.stage;
+      setSyncStage(() => currentStage);
+    }
+
+    if (!shouldFetch)
+      shouldFetch =
+        lastStage &&
+        lastStage >= SyncStage.OpenRuns &&
+        lastStage <= SyncStage.CompletedPlans &&
+        lastStage !== currentStage;
+
+    // Fetch data on first load or if new runs potentially synced
+    if (shouldFetch) fetchSearchKeys();
+  }, [projects, syncData]);
+
+  const buildTree: (
+    fields: Aha.ExtensionField[],
+    referenceMatches: number[]
+  ) => Promise<TreeNode[]> = useCallback(
+    async (fields, referenceMatches) => {
+      let children = fields.map(field => field.value as TestRun);
+
+      const runsToFetch = referenceMatches.filter(
+        id => !children.some(child => child.id === id)
+      );
+
+      if (runsToFetch.length > 0) {
+        const records = await getRecords<TestRun>(runsToFetch, 'TestRun');
+        children = children.concat(records);
+      }
+
+      children.sort((a, b) => b.id - a.id);
+
+      const nodes = children.map(record => ({
+        value: record.id.toString(),
+        text: record.name,
+        date: record.createdOn * 1000,
+        meta: record,
+      }));
+
+      const project = projects.find(p => p.id === projectId);
+
+      if (!project || nodes.length === 0) {
+        return [];
+      }
+
+      return [
+        {
+          value: projectId.toString(),
+          text: project.name,
+          children: nodes,
+        },
+      ];
+    },
+    [projects, projectId]
+  );
+
+  const searchIds = useMemo(
+    () => searchMapping[indexKeyForKindAndParent('TestRun', projectId)] || [],
+    [searchMapping, projectId]
+  );
+
+  console.log('Search IDs:', searchIds);
+
+  return (
+    <ApiSearch
+      searchIds={searchIds}
+      selected={selectedRunIds}
+      linkedIds={runIds}
+      searchKind={'TestRun'}
+      searchKey={'name'}
+      onSelect={updateSelectedRuns}
+      buildTree={buildTree}
+      recordName='test run'
+      referencePrefix='R'
+      loading={loading}
+      label='Select a test run'
+      placeholder='No synced test runs found.'
+    >
+      {syncing && <SyncProgress syncData={syncData} />}
+    </ApiSearch>
+  );
+};
+
+export default SelectTestRun;

--- a/src/components/modals/SelectTestRun.tsx
+++ b/src/components/modals/SelectTestRun.tsx
@@ -20,6 +20,7 @@ type Props = {
     isSelected: boolean,
     meta?: any
   ) => Promise<void>;
+  filter?: (run: TestRun) => boolean;
 };
 
 const SelectTestRun: React.FC<Props> = ({
@@ -29,6 +30,7 @@ const SelectTestRun: React.FC<Props> = ({
   projects,
   projectId,
   updateSelectedRuns,
+  filter,
 }) => {
   const [loading, setLoading] = useState(true);
   const [syncing, setSyncing] = useState(null); // True if syncing on initial load
@@ -96,6 +98,10 @@ const SelectTestRun: React.FC<Props> = ({
       if (runsToFetch.length > 0) {
         const records = await getRecords<TestRun>(runsToFetch, 'TestRun');
         children = children.concat(records);
+      }
+
+      if (filter) {
+        children = children.filter(run => filter(run));
       }
 
       children.sort((a, b) => b.id - a.id);

--- a/src/components/modals/SelectTestRun.tsx
+++ b/src/components/modals/SelectTestRun.tsx
@@ -46,7 +46,6 @@ const SelectTestRun: React.FC<Props> = ({
 
       const mapping = await getAccountExtensionFieldMap<number[]>(keys);
       setSearchMapping(() => mapping);
-      console.log('Search mapping:', mapping);
       setLoading(() => false);
     };
 
@@ -129,8 +128,6 @@ const SelectTestRun: React.FC<Props> = ({
     () => searchMapping[indexKeyForKindAndParent('TestRun', projectId)] || [],
     [searchMapping, projectId]
   );
-
-  console.log('Search IDs:', searchIds);
 
   return (
     <ApiSearch

--- a/src/components/tabs/FeatureTab.tsx
+++ b/src/components/tabs/FeatureTab.tsx
@@ -135,6 +135,7 @@ const FeatureTab: React.FC<TabProps> = ({ record, fields, settings }) => {
   // Prevent errors if a linked record was deleted (e.g. from the suite ignore-list)
   const existingCaseIds = testCases.map(testCase => testCase.id);
   const existingRunIds = runs.map(run => run.id);
+  const existingTestIds = Object.values(tests).map(test => test.id);
 
   if (testCases.length > 0) {
     caseRows = testCases.map(testCase => {
@@ -243,6 +244,7 @@ const FeatureTab: React.FC<TabProps> = ({ record, fields, settings }) => {
           <LinkTest
             record={record}
             caseIds={existingCaseIds}
+            testIds={existingTestIds}
             syncData={syncData}
             onClose={onClose(setLinkTestModalOpen)}
           />

--- a/src/lib/extensionFields/queries.test.ts
+++ b/src/lib/extensionFields/queries.test.ts
@@ -8,7 +8,6 @@ import {
   getProjectRecords,
   getProjectSuiteMapping,
   getLinkedComments,
-  getRunMapForTestCase,
   getAllRunIds,
   getRunRowData,
 } from './queries';
@@ -326,78 +325,6 @@ describe('getLinkedComments', () => {
       1: mockComments['test_1_comment'],
       2: mockComments['test_2_comment'],
     });
-  });
-});
-
-describe('getRunMapForTestCase', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('returns empty array when no runs exist', async () => {
-    mockGetExtensionField.mockResolvedValue([]);
-
-    const testCase: TestCase = {
-      id: 1,
-      projectId: 1,
-      kind: 'TestCase',
-      suiteId: 1,
-      title: 'Test Case',
-      createdOn: 123,
-    };
-
-    const result = await getRunMapForTestCase(testCase);
-    expect(result).toEqual([]);
-  });
-
-  it('maps runs and tests correctly', async () => {
-    const testCase: TestCase = {
-      id: 1,
-      projectId: 1,
-      kind: 'TestCase',
-      suiteId: 1,
-      title: 'Test Case',
-      createdOn: 123,
-    };
-
-    const mockRuns = [
-      {
-        id: 1,
-        name: 'Run 1',
-        createdOn: 123,
-        kind: 'TestRun',
-        projectId: 1,
-        suiteId: 1,
-        completed: false,
-      },
-      {
-        id: 2,
-        name: 'Run 2',
-        createdOn: 456,
-        kind: 'TestRun',
-        projectId: 1,
-        suiteId: 1,
-        completed: false,
-      },
-    ];
-
-    const mockTests = [
-      { id: 1, runId: 1, caseId: 1, statusId: 1, kind: 'Test' },
-      { id: 2, runId: 2, caseId: 1, statusId: 1, kind: 'Test' },
-    ];
-
-    mockGetExtensionField.mockResolvedValue([1, 2]);
-    mockQueryFields
-      .mockResolvedValueOnce(mockRuns.map(run => ({ value: run })))
-      .mockResolvedValueOnce([{ value: [1, 2] }])
-      .mockResolvedValueOnce(mockTests.map(test => ({ value: test })));
-
-    const result = await getRunMapForTestCase(testCase);
-
-    expect(result).toEqual([
-      [mockTests[1], mockRuns[1].name, mockRuns[1].createdOn],
-      [mockTests[0], mockRuns[0].name, mockRuns[0].createdOn],
-    ]);
   });
 });
 

--- a/src/lib/extensionFields/queries.ts
+++ b/src/lib/extensionFields/queries.ts
@@ -216,38 +216,6 @@ export const getLinkedComments: (ids: number[]) => Promise<{
   );
 };
 
-export const getRunMapForTestCase: (
-  testCase: TestCase
-) => Promise<[Test, string, number][]> = async testCase => {
-  const runIds = await aha.account.getExtensionField<number[]>(
-    IDENTIFIER,
-    indexKeyForKindAndParent('TestRun', testCase.projectId)
-  );
-
-  if (!runIds || runIds.length === 0) return [];
-
-  const runs = await getRecords<TestRun>(runIds, 'TestRun');
-  const runMap = runs.reduce((acc, run) => ({ ...acc, [run.id]: run }), {});
-
-  const testKeys = runs.map(run => indexKeyForKindAndParent('Test', run.id));
-  const testIds = (await getAccountExtensionFields<number[]>(testKeys)).flat();
-  const tests = await getRecords<Test>(testIds, 'Test');
-
-  const result: [Test, string, number][] = [];
-
-  for (const test of tests) {
-    if (test.caseId === testCase.id) {
-      const run = runMap[test.runId];
-
-      if (!run) continue;
-
-      result.push([test, run.name, run.createdOn]);
-    }
-  }
-
-  return result;
-};
-
 // Used when individual syncing tests and results - note that this is potentially less
 // performant than even bulk sync, depending on the number of saved completed runs.
 export const getAllRunIds: () => Promise<number[]> = async () => {

--- a/src/lib/extensionFields/updates.ts
+++ b/src/lib/extensionFields/updates.ts
@@ -18,15 +18,27 @@ export const linkRecord: (
   id: number,
   key: string
 ) => Promise<void> = async (record, id, key) => {
-  let existingIds = await record.getExtensionField<number[]>(IDENTIFIER, key);
+  linkRecords(record, [id], key);
+};
 
-  if (!existingIds) existingIds = [];
+export const linkRecords: (
+  record: ExtensionRecord,
+  ids: number[],
+  key: string
+) => Promise<void> = async (record, ids, key) => {
+  if (ids.length === 0) return;
 
-  if (existingIds.includes(id)) return;
+  let indexField = await record.getExtensionField<number[]>(IDENTIFIER, key);
 
-  existingIds.push(id);
+  if (!indexField) indexField = [];
 
-  await record.setExtensionField(IDENTIFIER, key, existingIds);
+  const existingIds = new Set(indexField);
+  ids = ids.filter(id => !existingIds.has(id));
+
+  if (ids.length === 0) return;
+
+  indexField = indexField.concat(ids);
+  await record.setExtensionField(IDENTIFIER, key, indexField);
 };
 
 export const unlinkRecord: (


### PR DESCRIPTION
Constructing a client-side search tree for linking wasn't scaling well - especially for tests. With many cases and many runs it got to the point where loading all records to construct the tree was too slow.

This update rewrites the modals to use the server-side extension field search functionality that was recently added - this should reduce the number of GQL calls that need to be made on load, especially for larger accounts.