### PR TITLE
Update create test case to optionally take values for the 'text' template

### DIFF
--- a/src/components/Styles.tsx
+++ b/src/components/Styles.tsx
@@ -353,6 +353,30 @@ export const Styles = () => {
         .ignore-button {
           padding-bottom: var(--spacer-2);
         }
+
+        .create-form {
+          display: flex;
+          flex-direction: column;
+          gap: var(--spacer-3);
+          margin-bottom: 20px;
+        }
+
+        .form-field {
+          display: flex;
+          gap: 20px;
+          align-items: center;
+        }
+
+        .field-label {
+          font-weight: 500;
+          font-size: var(--font-size-100);
+          line-height: var(--line-height-t-050);
+          width: 110px;
+        }
+
+        .full-width {
+          flex-grow: 1;
+        }
       `}
     </style>
   );

--- a/src/components/modals/CreateTestCase.tsx
+++ b/src/components/modals/CreateTestCase.tsx
@@ -23,6 +23,9 @@ type CreateProps = {
   domain: string;
   record: ExtensionRecord;
   title: string;
+  precondition: string;
+  steps: string;
+  results: string;
   sectionId: string;
   projectId: string;
   setSaving: (saving: boolean) => void;
@@ -146,6 +149,9 @@ const createTestCase: (props: CreateProps) => Promise<boolean> = async ({
   record,
   domain,
   title,
+  precondition,
+  steps,
+  results,
   sectionId,
   projectId,
   setSaving,
@@ -166,6 +172,9 @@ const createTestCase: (props: CreateProps) => Promise<boolean> = async ({
   const args = {
     domain,
     title,
+    precondition,
+    steps,
+    results,
     sectionId: sectionIdNum,
     projectId: projectIdNum,
   };
@@ -198,8 +207,14 @@ const CreateTestCase: React.FC<Props> = ({
 }) => {
   const modalRef = useRef(null);
   const titleRef = useRef(null);
+  const preconditionRef = useRef(null);
+  const stepsRef = useRef(null);
+  const resultsRef = useRef(null);
 
-  const [title, setTitle] = useState('');
+  const [title, setTitle] = useState<string>('');
+  const [precondition, setPrecondition] = useState<string>('');
+  const [steps, setSteps] = useState<string>('');
+  const [results, setResults] = useState<string>('');
 
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -227,6 +242,9 @@ const CreateTestCase: React.FC<Props> = ({
       domain,
       record,
       title: titleRef.current.value,
+      precondition: preconditionRef.current.value,
+      steps: stepsRef.current.value,
+      results: resultsRef.current.value,
       sectionId: sectionIdRef.current,
       projectId: projectIdRef.current,
       setSaving,
@@ -298,15 +316,43 @@ const CreateTestCase: React.FC<Props> = ({
             please contact <a href='mailto:support@aha.io'>support@aha.io</a>.
           </aha-alert>
         )}
-        <aha-field class='left-align-input' required>
-          <div slot='label'>Name</div>
-          <input
-            ref={titleRef}
-            type='text'
-            placeholder='Enter test case name'
-            onInput={event => setTitle(event.target.value)}
-          />
-        </aha-field>
+        <div class='create-form'>
+          <div class='form-field'>
+            <div class='field-label'>
+              Name<span class='label-required'>*</span>
+            </div>
+            <input
+              ref={titleRef}
+              type='text'
+              onInput={event => setTitle(event.target.value)}
+              class='full-width'
+            />
+          </div>
+          <div class='form-field'>
+            <div class='field-label'>Preconditions</div>
+            <textarea
+              ref={preconditionRef}
+              onInput={event => setPrecondition(event.target.value)}
+              class='full-width'
+            />
+          </div>
+          <div class='form-field'>
+            <div class='field-label'>Steps</div>
+            <textarea
+              ref={stepsRef}
+              onInput={event => setSteps(event.target.value)}
+              class='full-width'
+            />
+          </div>
+          <div class='form-field'>
+            <div class='field-label'>Expected results</div>
+            <textarea
+              ref={resultsRef}
+              onInput={event => setResults(event.target.value)}
+              class='full-width'
+            />
+          </div>
+        </div>
         <div className='search-form'>
           <SearchByName
             tree={sectionTree}

--- a/src/events/createTestCase.ts
+++ b/src/events/createTestCase.ts
@@ -5,6 +5,9 @@ type CreateProps = BaseParams & {
   projectId: number;
   sectionId: number;
   title: string;
+  precondition: string;
+  steps: string;
+  results: string;
 };
 
 const createTestCase: (props: CreateProps) => Promise<void> = async ({
@@ -12,6 +15,9 @@ const createTestCase: (props: CreateProps) => Promise<void> = async ({
   projectId,
   sectionId,
   title,
+  precondition,
+  steps,
+  results,
   record,
   eventKey,
 }) => {
@@ -20,7 +26,13 @@ const createTestCase: (props: CreateProps) => Promise<void> = async ({
       `Beginning TestRail test case create for section: ${sectionId}`
     );
 
-    const body = { title };
+    const body = {
+      title,
+      template_id: 1,
+      custom_preconds: precondition,
+      custom_steps: steps,
+      custom_expected: results,
+    };
 
     const json = await fetchTestRail({
       domain,
@@ -61,13 +73,25 @@ const createTestCase: (props: CreateProps) => Promise<void> = async ({
 
 aha.on(
   { event: `${IDENTIFIER}.createTestCase` },
-  async ({ domain, eventKey, projectId, sectionId, title }) => {
+  async ({
+    domain,
+    eventKey,
+    projectId,
+    sectionId,
+    title,
+    precondition,
+    steps,
+    results,
+  }) => {
     await createTestCase({
       record: aha.account,
       domain,
       projectId,
       sectionId,
       title,
+      precondition,
+      steps,
+      results,
       eventKey,
     });
   }


### PR DESCRIPTION
The text template is the default template for test cases - preconditions/steps/expected results. The created test cases were already using this template, but not providing any values - this change updates the modal to allow people to set desired values.

<img width="792" height="777" alt="Screenshot 2025-08-06 at 9 24 55 AM" src="https://github.com/user-attachments/assets/a09a426e-996e-4be0-9c26-682f37db6f96" />
