### PR TITLE
IMTEAM-715 Replace ids when syncing data to avoid stale references

### DIFF
--- a/src/lib/extensionFields/queries.test.ts
+++ b/src/lib/extensionFields/queries.test.ts
@@ -115,7 +115,7 @@ describe('indexKeyForRecord', () => {
     ).toBe('project_2_caseIds');
   });
 
-  it('returns correct key for TestRun with project', () => {
+  it('returns correct key for open TestRun with project', () => {
     expect(
       indexKeyForRecord({
         kind: 'TestRun',
@@ -126,7 +126,21 @@ describe('indexKeyForRecord', () => {
         createdOn: 123,
         completed: false,
       })
-    ).toBe('project_2_runIds');
+    ).toBe('project_2_openRunIds');
+  });
+
+  it('returns correct key for completed TestRun with project', () => {
+    expect(
+      indexKeyForRecord({
+        kind: 'TestRun',
+        id: 1,
+        projectId: 2,
+        suiteId: 3,
+        name: 'Test Run',
+        createdOn: 123,
+        completed: true,
+      })
+    ).toBe('project_2_completedRunIds');
   });
 
   it('returns correct key for Test with run', () => {
@@ -169,6 +183,18 @@ describe('indexKeyForKindAndParent', () => {
 
   it('returns correct key for TestCase with project', () => {
     expect(indexKeyForKindAndParent('TestCase', 1)).toBe('project_1_caseIds');
+  });
+
+  it('returns correct key for OpenRun with project', () => {
+    expect(indexKeyForKindAndParent('OpenRun', 1)).toBe(
+      'project_1_openRunIds'
+    );
+  });
+
+  it('returns correct key for CompletedRun with project', () => {
+    expect(indexKeyForKindAndParent('CompletedRun', 1)).toBe(
+      'project_1_completedRunIds'
+    );
   });
 
   it('returns correct key for Test with run', () => {

--- a/src/lib/extensionFields/queries.test.ts
+++ b/src/lib/extensionFields/queries.test.ts
@@ -372,6 +372,12 @@ describe('getAllRunIds', () => {
 
     const result = await getAllRunIds();
 
+    expect(mockQueryFields).toHaveBeenCalledWith([
+      'project_1_openRunIds',
+      'project_1_completedRunIds',
+      'project_2_openRunIds',
+      'project_2_completedRunIds',
+    ]);
     expect(result).toEqual([1, 2, 3, 4]);
   });
 });

--- a/src/lib/extensionFields/queries.ts
+++ b/src/lib/extensionFields/queries.ts
@@ -145,7 +145,6 @@ export const getProjectRecords: <
 
   if (kind === 'TestRun') {
     keys = projectIds.flatMap(projectId => [
-      indexKeyForKindAndParent('TestRun', projectId),
       indexKeyForKindAndParent('OpenRun', projectId),
       indexKeyForKindAndParent('CompletedRun', projectId),
     ]);
@@ -155,9 +154,7 @@ export const getProjectRecords: <
     );
   }
 
-  const ids = [
-    ...new Set((await getAccountExtensionFields<number[]>(keys)).flat()),
-  ];
+  const ids = (await getAccountExtensionFields<number[]>(keys)).flat();
 
   const records = await getRecords<T>(ids, kind);
 
@@ -253,14 +250,11 @@ export const getAllRunIds: () => Promise<number[]> = async () => {
   if (!projectIds || projectIds.length === 0) return [];
 
   const keys = projectIds.flatMap(projectId => [
-    indexKeyForKindAndParent('TestRun', projectId),
     indexKeyForKindAndParent('OpenRun', projectId),
     indexKeyForKindAndParent('CompletedRun', projectId),
   ]);
 
-  const runIds = (await getAccountExtensionFields<number[]>(keys)).flat();
-
-  return [...new Set(runIds)];
+  return (await getAccountExtensionFields<number[]>(keys)).flat();
 };
 
 export const getRunRowData: (

--- a/src/lib/extensionFields/queries.ts
+++ b/src/lib/extensionFields/queries.ts
@@ -45,8 +45,12 @@ export const indexKeyForRecord: (
     case 'Suite':
     case 'Section':
     case 'TestCase':
-    case 'TestRun':
       return indexKeyForKindAndParent(record.kind, record.projectId);
+    case 'TestRun':
+      return indexKeyForKindAndParent(
+        record.completed ? 'CompletedRun' : 'OpenRun',
+        record.projectId
+      );
     case 'Test':
       return indexKeyForKindAndParent(record.kind, record.runId);
     case 'TestResult':
@@ -54,8 +58,14 @@ export const indexKeyForRecord: (
   }
 };
 
+export type IndexKind =
+  | TestRailRecord['kind']
+  | 'TestResult'
+  | 'OpenRun'
+  | 'CompletedRun';
+
 export const indexKeyForKindAndParent: (
-  kind: TestRailRecord['kind'] | 'TestResult',
+  kind: IndexKind,
   parentId?: number
 ) => string = (kind, parentId) => {
   switch (kind) {
@@ -71,6 +81,10 @@ export const indexKeyForKindAndParent: (
       return `project_${parentId}_caseIds`;
     case 'TestRun':
       return `project_${parentId}_runIds`;
+    case 'OpenRun':
+      return `project_${parentId}_openRunIds`;
+    case 'CompletedRun':
+      return `project_${parentId}_completedRunIds`;
     case 'Test':
       return `run_${parentId}_testIds`;
     case 'TestResult':
@@ -127,11 +141,23 @@ export const getProjectRecords: <
 
   const mapping: { [projectId: number]: T[] } = {};
 
-  const keys = projectIds.map(projectId =>
-    indexKeyForKindAndParent(kind, projectId)
-  );
+  let keys: string[];
 
-  const ids = (await getAccountExtensionFields<number[]>(keys)).flat();
+  if (kind === 'TestRun') {
+    keys = projectIds.flatMap(projectId => [
+      indexKeyForKindAndParent('TestRun', projectId),
+      indexKeyForKindAndParent('OpenRun', projectId),
+      indexKeyForKindAndParent('CompletedRun', projectId),
+    ]);
+  } else {
+    keys = projectIds.map(projectId =>
+      indexKeyForKindAndParent(kind, projectId)
+    );
+  }
+
+  const ids = [
+    ...new Set((await getAccountExtensionFields<number[]>(keys)).flat()),
+  ];
 
   const records = await getRecords<T>(ids, kind);
 
@@ -226,13 +252,15 @@ export const getAllRunIds: () => Promise<number[]> = async () => {
 
   if (!projectIds || projectIds.length === 0) return [];
 
-  const keys = projectIds.map(projectId =>
-    indexKeyForKindAndParent('TestRun', projectId)
-  );
+  const keys = projectIds.flatMap(projectId => [
+    indexKeyForKindAndParent('TestRun', projectId),
+    indexKeyForKindAndParent('OpenRun', projectId),
+    indexKeyForKindAndParent('CompletedRun', projectId),
+  ]);
 
   const runIds = (await getAccountExtensionFields<number[]>(keys)).flat();
 
-  return runIds;
+  return [...new Set(runIds)];
 };
 
 export const getRunRowData: (

--- a/src/lib/extensionFields/updates.test.ts
+++ b/src/lib/extensionFields/updates.test.ts
@@ -140,7 +140,7 @@ describe('saveRecords', () => {
     });
 
     expect(mockSetExtensionFields).toHaveBeenNthCalledWith(2, IDENTIFIER, {
-      project_100_caseIds: [3, 4, 1],
+      project_100_caseIds: [1],
       project_200_caseIds: [2],
     });
   });
@@ -183,10 +183,6 @@ describe('saveNewRuns', () => {
       run_2: { completed: true },
     });
 
-    mockGetExtensionMap.mockResolvedValueOnce({
-      project_100_runIds: [3, 4],
-    });
-
     const result = await saveNewRuns(runs);
 
     expect(result).toHaveLength(1);
@@ -197,7 +193,7 @@ describe('saveNewRuns', () => {
     });
 
     expect(mockSetExtensionFields).toHaveBeenNthCalledWith(2, IDENTIFIER, {
-      project_100_runIds: [3, 4, 1],
+      project_100_openRunIds: [1],
     });
   });
 

--- a/src/lib/extensionFields/updates.ts
+++ b/src/lib/extensionFields/updates.ts
@@ -109,17 +109,13 @@ const updateRecordIndexes: <T extends TestRailRecord>(
     keyMap[indexKey].push(record);
   }
 
-  const existingIndexes = await getAccountExtensionFieldMap<number[]>(
-    Object.keys(keyMap)
-  );
-
   const fields = [];
 
   for (const key in keyMap) {
-    let allIds = existingIndexes[key] ?? [];
-    allIds.push(...keyMap[key].map(record => record.id));
-
-    fields.push([key, Array.from(new Set(allIds))]);
+    fields.push([
+      key,
+      Array.from(new Set(keyMap[key].map(record => record.id))),
+    ]);
   }
 
   await saveChunked(fields);

--- a/src/lib/ignore.test.ts
+++ b/src/lib/ignore.test.ts
@@ -199,12 +199,10 @@ describe('deleteIgnoredSuiteRecords', () => {
     const expectedIndexUpdates = {
       project_10_sectionIds: [102],
       project_10_caseIds: [302],
-      project_10_runIds: [502],
       project_10_openRunIds: [502],
       project_10_completedRunIds: [],
       project_20_sectionIds: [],
       project_20_caseIds: [],
-      project_20_runIds: [],
       project_20_openRunIds: [],
       project_20_completedRunIds: [],
     };

--- a/src/lib/ignore.test.ts
+++ b/src/lib/ignore.test.ts
@@ -200,9 +200,13 @@ describe('deleteIgnoredSuiteRecords', () => {
       project_10_sectionIds: [102],
       project_10_caseIds: [302],
       project_10_runIds: [502],
+      project_10_openRunIds: [502],
+      project_10_completedRunIds: [],
       project_20_sectionIds: [],
       project_20_caseIds: [],
       project_20_runIds: [],
+      project_20_openRunIds: [],
+      project_20_completedRunIds: [],
     };
 
     expect(mockSetExtensionFields).toHaveBeenCalledWith(

--- a/src/lib/ignore.ts
+++ b/src/lib/ignore.ts
@@ -43,6 +43,8 @@ export const deleteIgnoredSuiteRecords: (
     const sectionsToKeep = [];
     const testCasesToKeep = [];
     const testRunsToKeep = [];
+    const openRunsToKeep = [];
+    const completedRunsToKeep = [];
     const deletedRuns = [];
 
     for (const section of projectSections) {
@@ -67,6 +69,11 @@ export const deleteIgnoredSuiteRecords: (
         recordsToDelete.push(fieldName('TestRun', testRun.id));
       } else {
         testRunsToKeep.push(testRun.id);
+        if (testRun.completed) {
+          completedRunsToKeep.push(testRun.id);
+        } else {
+          openRunsToKeep.push(testRun.id);
+        }
       }
     }
 
@@ -75,8 +82,11 @@ export const deleteIgnoredSuiteRecords: (
       indexesToUpdate[`project_${projectId}_sectionIds`] = sectionsToKeep;
     if (projectTestCases.length > 0)
       indexesToUpdate[`project_${projectId}_caseIds`] = testCasesToKeep;
-    if (projectTestRuns.length > 0)
+    if (projectTestRuns.length > 0) {
       indexesToUpdate[`project_${projectId}_runIds`] = testRunsToKeep;
+      indexesToUpdate[`project_${projectId}_openRunIds`] = openRunsToKeep;
+      indexesToUpdate[`project_${projectId}_completedRunIds`] = completedRunsToKeep;
+    }
 
     // Delete any tests and results associated with deleted runs
     if (deletedRuns.length > 0) {

--- a/src/lib/ignore.ts
+++ b/src/lib/ignore.ts
@@ -42,7 +42,6 @@ export const deleteIgnoredSuiteRecords: (
 
     const sectionsToKeep = [];
     const testCasesToKeep = [];
-    const testRunsToKeep = [];
     const openRunsToKeep = [];
     const completedRunsToKeep = [];
     const deletedRuns = [];
@@ -68,7 +67,6 @@ export const deleteIgnoredSuiteRecords: (
         deletedRuns.push(testRun.id);
         recordsToDelete.push(fieldName('TestRun', testRun.id));
       } else {
-        testRunsToKeep.push(testRun.id);
         if (testRun.completed) {
           completedRunsToKeep.push(testRun.id);
         } else {
@@ -83,7 +81,6 @@ export const deleteIgnoredSuiteRecords: (
     if (projectTestCases.length > 0)
       indexesToUpdate[`project_${projectId}_caseIds`] = testCasesToKeep;
     if (projectTestRuns.length > 0) {
-      indexesToUpdate[`project_${projectId}_runIds`] = testRunsToKeep;
       indexesToUpdate[`project_${projectId}_openRunIds`] = openRunsToKeep;
       indexesToUpdate[`project_${projectId}_completedRunIds`] = completedRunsToKeep;
     }


### PR DESCRIPTION
A customer deleted a test suite, and the extension is holding onto its id. Querying the TestRail API using the deleted id returns a 400 response code that blocks syncing. Any of the TestRail entities can be deleted, so we should replace the list of ids instead of appending to it.

The replace-on-sync behavior worked for most entities as is but not for test runs. Runs can be open or completed, and previously we appended the ids for both types into the same index. To make test runs work with the new replace behavior, we are now storing each type of run in its own index. 