### PR TITLE
IMTEAM-717 Normalize domain setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,9 +112,9 @@
       },
       "settings": {
         "domain": {
-          "title": "TestRail Domain",
+          "title": "TestRail Subdomain",
           "type": "string",
-          "description": "The domain of your TestRail instance",
+          "description": "The subdomain of your TestRail instance, e.g. enter 'myteam' if your TestRail instance is accessible at https://myteam.testrail.io/",
           "scope": [
             "account"
           ]

--- a/src/components/RecordLink.tsx
+++ b/src/components/RecordLink.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { TestRailRecord } from '../extension';
+import { normalizeDomain } from '../lib/api';
 
 type Props = {
   record: TestRailRecord;
@@ -14,15 +15,15 @@ const RecordLink: React.FC<Props> = ({ record, domain }) => {
 
   switch (record.kind) {
     case 'TestCase':
-      url = `https://${domain}.testrail.io/index.php?/cases/view/${record.id}`;
+      url = `https://${normalizeDomain(domain)}.testrail.io/index.php?/cases/view/${record.id}`;
       prefix = 'C';
       break;
     case 'TestRun':
-      url = `https://${domain}.testrail.io/index.php?/runs/view/${record.id}`;
+      url = `https://${normalizeDomain(domain)}.testrail.io/index.php?/runs/view/${record.id}`;
       prefix = 'R';
       break;
     case 'Test':
-      url = `https://${domain}.testrail.io/index.php?/tests/view/${record.id}`;
+      url = `https://${normalizeDomain(domain)}.testrail.io/index.php?/tests/view/${record.id}`;
       prefix = 'T';
       break;
     default:

--- a/src/components/RecordLink.tsx
+++ b/src/components/RecordLink.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TestRailRecord } from '../extension';
-import { normalizeDomain } from '../lib/api';
+import { normalizeSubdomain } from '../lib/api';
 
 type Props = {
   record: TestRailRecord;
@@ -15,15 +15,15 @@ const RecordLink: React.FC<Props> = ({ record, domain }) => {
 
   switch (record.kind) {
     case 'TestCase':
-      url = `https://${normalizeDomain(domain)}.testrail.io/index.php?/cases/view/${record.id}`;
+      url = `https://${normalizeSubdomain(domain)}.testrail.io/index.php?/cases/view/${record.id}`;
       prefix = 'C';
       break;
     case 'TestRun':
-      url = `https://${normalizeDomain(domain)}.testrail.io/index.php?/runs/view/${record.id}`;
+      url = `https://${normalizeSubdomain(domain)}.testrail.io/index.php?/runs/view/${record.id}`;
       prefix = 'R';
       break;
     case 'Test':
-      url = `https://${normalizeDomain(domain)}.testrail.io/index.php?/tests/view/${record.id}`;
+      url = `https://${normalizeSubdomain(domain)}.testrail.io/index.php?/tests/view/${record.id}`;
       prefix = 'T';
       break;
     default:

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -9,8 +9,8 @@ describe('normalizeSubdomain', () => {
     expect(normalizeSubdomain('http://myteam.testrail.io')).toBe('myteam');
   });
 
-  it('handles trailing slash', () => {
-    expect(normalizeSubdomain('https://myteam.testrail.io/')).toBe('myteam');
+  it('handles trailing characters', () => {
+    expect(normalizeSubdomain('https://myteam.testrail.io/index.php')).toBe('myteam');
   });
 
   it('strips .testrail.io without protocol', () => {

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,31 +1,31 @@
-import { normalizeDomain } from './api';
+import { normalizeSubdomain } from './api';
 
-describe('normalizeDomain', () => {
+describe('normalizeSubdomain', () => {
   it('strips https:// protocol and .testrail.io suffix', () => {
-    expect(normalizeDomain('https://myteam.testrail.io')).toBe('myteam');
+    expect(normalizeSubdomain('https://myteam.testrail.io')).toBe('myteam');
   });
 
   it('strips http:// protocol', () => {
-    expect(normalizeDomain('http://myteam.testrail.io')).toBe('myteam');
+    expect(normalizeSubdomain('http://myteam.testrail.io')).toBe('myteam');
   });
 
   it('handles trailing slash', () => {
-    expect(normalizeDomain('https://myteam.testrail.io/')).toBe('myteam');
+    expect(normalizeSubdomain('https://myteam.testrail.io/')).toBe('myteam');
   });
 
   it('strips .testrail.io without protocol', () => {
-    expect(normalizeDomain('myteam.testrail.io')).toBe('myteam');
+    expect(normalizeSubdomain('myteam.testrail.io')).toBe('myteam');
   });
 
   it('returns plain subdomain unchanged', () => {
-    expect(normalizeDomain('myteam')).toBe('myteam');
+    expect(normalizeSubdomain('myteam')).toBe('myteam');
   });
 
   it('trims whitespace', () => {
-    expect(normalizeDomain('  myteam  ')).toBe('myteam');
+    expect(normalizeSubdomain('  myteam  ')).toBe('myteam');
   });
 
   it('handles capitalization', () => {
-    expect(normalizeDomain('HTTPS://MYTEAM.TESTRAIL.IO')).toBe('myteam');
+    expect(normalizeSubdomain('HTTPS://MYTEAM.TESTRAIL.IO')).toBe('myteam');
   });
 });

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -20,4 +20,12 @@ describe('normalizeDomain', () => {
   it('returns plain subdomain unchanged', () => {
     expect(normalizeDomain('myteam')).toBe('myteam');
   });
+
+  it('trims whitespace', () => {
+    expect(normalizeDomain('  myteam  ')).toBe('myteam');
+  });
+
+  it('handles capitalization', () => {
+    expect(normalizeDomain('HTTPS://MYTEAM.TESTRAIL.IO')).toBe('myteam');
+  });
 });

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,0 +1,23 @@
+import { normalizeDomain } from './api';
+
+describe('normalizeDomain', () => {
+  it('strips https:// protocol and .testrail.io suffix', () => {
+    expect(normalizeDomain('https://myteam.testrail.io')).toBe('myteam');
+  });
+
+  it('strips http:// protocol', () => {
+    expect(normalizeDomain('http://myteam.testrail.io')).toBe('myteam');
+  });
+
+  it('handles trailing slash', () => {
+    expect(normalizeDomain('https://myteam.testrail.io/')).toBe('myteam');
+  });
+
+  it('strips .testrail.io without protocol', () => {
+    expect(normalizeDomain('myteam.testrail.io')).toBe('myteam');
+  });
+
+  it('returns plain subdomain unchanged', () => {
+    expect(normalizeDomain('myteam')).toBe('myteam');
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,7 +3,7 @@ import { ExtensionRecord } from './extensionRecord';
 import base64 from 'base64-js';
 
 export const normalizeDomain = (domain: string): string =>
-  domain.replace(/^https?:\/\//, '').replace(/\.testrail\.io\/?$/, '');
+  domain.trim().toLowerCase().replace(/^https?:\/\//, '').replace(/\.testrail\.io\/?$/, '');
 
 export type APIResult = {
   message?: string;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,7 +3,7 @@ import { ExtensionRecord } from './extensionRecord';
 import base64 from 'base64-js';
 
 export const normalizeSubdomain = (domain: string): string =>
-  domain.trim().toLowerCase().replace(/^https?:\/\//, '').replace(/\.testrail\.io\/?$/, '');
+  domain.trim().toLowerCase().replace(/^https?:\/\//, '').replace(/\.testrail\.io.*/, '');
 
 export type APIResult = {
   message?: string;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,7 +2,7 @@ import { IDENTIFIER } from '../extension';
 import { ExtensionRecord } from './extensionRecord';
 import base64 from 'base64-js';
 
-export const normalizeDomain = (domain: string): string =>
+export const normalizeSubdomain = (domain: string): string =>
   domain.trim().toLowerCase().replace(/^https?:\/\//, '').replace(/\.testrail\.io\/?$/, '');
 
 export type APIResult = {
@@ -97,7 +97,7 @@ export const fetchTestRail: (props: FetchParams) => Promise<any> = async ({
   method = 'GET',
   body,
 }) => {
-  const url = `https://${normalizeDomain(domain)}.testrail.io/index.php?/api/v2/${path}`;
+  const url = `https://${normalizeSubdomain(domain)}.testrail.io/index.php?/api/v2/${path}`;
 
   const headers = getHeaders();
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,6 +2,9 @@ import { IDENTIFIER } from '../extension';
 import { ExtensionRecord } from './extensionRecord';
 import base64 from 'base64-js';
 
+export const normalizeDomain = (domain: string): string =>
+  domain.replace(/^https?:\/\//, '').replace(/\.testrail\.io\/?$/, '');
+
 export type APIResult = {
   message?: string;
   result?: any;
@@ -94,7 +97,7 @@ export const fetchTestRail: (props: FetchParams) => Promise<any> = async ({
   method = 'GET',
   body,
 }) => {
-  const url = `https://${domain}.testrail.io/index.php?/api/v2/${path}`;
+  const url = `https://${normalizeDomain(domain)}.testrail.io/index.php?/api/v2/${path}`;
 
   const headers = getHeaders();
 


### PR DESCRIPTION
When configuring the extension for the first time, I mistakenly entered the full url as the domain setting. This created a malformed url, e.g. `https://https://myteam.testrail.io.testrail.io/`